### PR TITLE
pull charts from nexus not locally

### DIFF
--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -1,47 +1,47 @@
 dependencies:
   - name: catalog
     version: '2.0.1'
-    repository: 'file://../catalog'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: data
     version: '2.0.1'
-    repository: 'file://../data'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: data
     version: '2.0.1'
-    repository: 'file://../data'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     alias: internal-data
 
   - name: dashboard
     version: '2.0.1'
-    repository: 'file://../dashboard'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: edge
     version: '2.0.1'
-    repository: 'file://../edge'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: jwt
     version: '2.0.1'
-    repository: 'file://../jwt'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: jwt
     version: '2.0.1'
-    repository: 'file://../jwt'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     alias: internal-jwt
 
   - name: slo
     version: '2.0.1'
-    repository: 'file://../slo'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: gm-control-api
-    repository: 'file://../gm-control-api'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     version: '2.0.1'
 
   - name: control
-    repository: 'file://../control'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     version: '2.0.1'
 
   - name: spire
-    repository: 'file://../spire'
+    repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     version: '2.0.1'
     condition: global.spire.enabled


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Sets the Grey Matter requirements to pull from nexus instead of locally

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

none

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

```console
➜  helm-charts git:(greymatter-req-update) helm dep update greymatter
Saving 11 charts
Downloading catalog from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading data from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading data from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading dashboard from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading edge from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading jwt from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading jwt from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading slo from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading gm-control-api from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading control from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Downloading spire from repo https://nexus.production.deciphernow.com/repository/helm-hosted
Deleting outdated charts
```