### PR TITLE
fix links to custom yaml in getting started

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -64,8 +64,8 @@ Each Helm chart has a `values.yaml` file which specifies the default values used
 
 We've provided two examples:
 
-- [greymatter-custom.yaml](./greymatter-custom.yaml): showcases the general structure of a Helm values file and shows how top-level values are passed down to subcharts
-- [greymatter-custom-secrets.yaml](./greymatter-custom-secrets.yaml): a values file containing just passwords, secrets, and other sensitive data
+- [greymatter-custom.yaml](../greymatter-custom.yaml): showcases the general structure of a Helm values file and shows how top-level values are passed down to subcharts
+- [greymatter-custom-secrets.yaml](../greymatter-custom-secrets.yaml): a values file containing just passwords, secrets, and other sensitive data
 
 ### Basic values
 


### PR DESCRIPTION
*Resolves #257

## Proposed Changes

  - `s^./greymatter-custom.yaml^../greymatter-custom.yaml^`
  - `s^./greymatter-custom-secrets.yaml^../greymatter-custom-secrets.yaml^`
  
## How to Test

  - View the modified file in the pull request and insure the links work.
