### PR TITLE
set default userfield to email in gm-data

### DIFF
--- a/greymatter.yaml
+++ b/greymatter.yaml
@@ -155,7 +155,7 @@ data:
         value: home
       gmdata_namespace_userfield:
         type: value
-        value: userDN
+        value: email
       jwt_pub:
         type: secret
         secret: jwt-security


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.
Closes #278 

The full description of why the fix was needed is in the above issue. 
<br/><br/>

2. What **changes to custom.yaml** are required?
I changed the default here to match the defaults in JWT server.  
<br/><br/>

3. Have you documented any additional setup steps or configurations options?
No
<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

After deploying the chart in minikube, users of the data ui can create home folders for their use.  
![dat](https://user-images.githubusercontent.com/2422189/65902763-bac06200-e380-11e9-95e1-dcfa39dfc2fe.png)
<br/>
<br/>
