### PR TITLE
Required changes for Sense to function properly.

### DIFF
--- a/dashboard/templates/prometheus-configmap.yaml
+++ b/dashboard/templates/prometheus-configmap.yaml
@@ -36,6 +36,24 @@ data:
           target_label:  'job'
           #replacement:   '${1}'
           replacement:   '${1}'
+      - job_name: sense
+        metrics_path: /stats/prometheus
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - {{ .Release.Namespace | quote }}
+        relabel_configs:
+        # Drop all named ports that are not "metrics"
+        - source_labels: ['__meta_kubernetes_pod_container_port_name']
+          regex: 'metrics'
+          action: 'keep'
+        # Relabel Jobs to the service name and version of the zk path
+        - source_labels: ['__meta_kubernetes_pod_label_app']
+          regex: '(.*)'
+          target_label:  'job'
+          #replacement:   '${1}'
+          replacement:   '${1}'
 
   # Copied from https://github.com/DecipherNow/gm-dashboard/blob/master/docker/prometheus/recording_rules.yml
   recording_rules.yaml: |-


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Sense project requires Envoy metrics to make recommendations. Having this configuration here will allow us the environment to be recreated consistently and reliably. 

<br/><br/>

> Hiromi Suenaga 2:18 PM
> Would anybody here know how to make `envoy_*` stats to appear here?
> https://greymatter.fabric-prod.staging.deciphernow.com/services/prometheus/latest/graph?g0.range_input=1h&g0.expr=%7Bjob%3D%22fibonacci-001%22%7D&g0.tab=1
> This is what I am hoping to achieve:
> https://greymatter.development.deciphernow.com/services/prometheus/graph?g0.range_input=1h&g0.expr=%7Bjob%3D%22fibonacci-scale-v2%22%7D&g0.tab=1
> 
> Justin Ely 2:21 PM
> https://github.com/DecipherNow/openshift-development/blob/master/deployments/control/core/prometheus/prometheus.yml#L31
> deployments/control/core/prometheus/prometheus.yml:31
>   - job_name: sense
> :lock: <https://github.com/DecipherNow/openshift-development|DecipherNow/openshift-development>:lock: DecipherNow/openshift-development | Added by GitHub
> 
> Justin Ely 2:21 PM
> @hiromi ^
> 
> Hiromi Suenaga 2:23 PM
> Thanks @justin.ely :slightly_smiling_face:  Can we add that to the default deployment of prometheus? Or do we need to do that after the core services are deployed?
> 
> Justin Ely 2:23 PM
> i don't think we want to
> it exposes the admin port of envoy to being scraped
> across the mesh
> what do you need it for?
> 
> Hiromi Suenaga 2:24 PM
> I need sense working in staging environment and demo environment
> and if at all possible, I do not want to change the yaml file manually every time the environments get rebuilt
> 
> Justin Ely 2:35 PM
> mhmm
> ok; well if you need it for demo, then i guess we can do it
> but we need a better plan for this going forward
> 
> Hiromi Suenaga 2:37 PM
> agreed. there’re quite a bit of environment discrepancies between staging and development (e.g. prometheus.yml in dev, prometheus.yaml in staging)
> 
> Daniel Cox:book: 2:47 PM
> It's way easier to expose the proxy admin port to Prometheus (and, if possible, only Prometheus) than it is to do it other ways I can think of.
> Unless it's easy now to inject custom routes that send incoming /metrics to /stats/prometheus on the sidecar (edited) 
> But the first way we did it was to inject custom envoy config instead of using the one generated by the mesh, (which I understand isn't feasible anymore) and an extra container to reformat the statsd metrics into prometheus formatting,
> and the second way we did it (iirc) was to just expose the admin port (8001) and make a custom Prometheus config so it would scrape :8001/stats/prometheus instead of :8081/metrics (edited) 
> 
> David Tillery 3:28 PM
> Only the demo environment, not staging.
> Staging and demo were deployed using the Helm charts FWIW.


2. What **changes to custom.yaml** are required?

N/A

3. Have you documented any additional setup steps or configurations options?

https://notes.deciphernow.com/t/staging-environment-service-deployment-scripts-in-making/752/3

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Currently running in demo environment:
https://gartner.demonstration.deciphernow.com/services/prometheus/latest/config

