### PR TITLE
update for running on raw k8s

### DIFF
--- a/dashboard/templates/prometheus.yaml
+++ b/dashboard/templates/prometheus.yaml
@@ -22,6 +22,13 @@ spec:
       securityContext:
         fsGroup: 65534
       {{- end }}  
+      {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
+      {{- else }}
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 0
+        fsGroup: 2000
+      {{- end }}
       containers:
       - name: prometheus
         image: {{ .Values.prometheus.image | quote }}

--- a/dashboard/templates/prometheus.yaml
+++ b/dashboard/templates/prometheus.yaml
@@ -22,8 +22,7 @@ spec:
       securityContext:
         fsGroup: 65534
       {{- end }}  
-      {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
-      {{- else }}
+      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
       securityContext:
         runAsUser: 2000
         runAsGroup: 0

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -52,13 +52,13 @@ At the top of `custom-greymatter.yaml`, set the following four values according 
 global:
   # used in our subcharts to apply platform specific settings, values can be `openshift` or `kubernetes` only
   environment: openshift
-  
+
   # the domain you're deploying to
   domain: development.deciphernow.com
-  
+
   # a string that will be prefixed to the final hostname of the deployment
   route_url_name: greymatter
-  
+
   # whether to include the virtual cluster namespace in the final hostname of the deployment
   remove_namespace_from_url: false
 ```
@@ -106,7 +106,7 @@ dockerCredentials:
 ### AWS credentials (optional)
 
 Set AWS credentials for gm-data to authenticate and push content to S3. This step is **optional** because gm-data stores files on disk or in S3. If you need credentials please contact [Grey Matter Support](https://support.deciphernow.com).
-  
+
 ```yaml
 data:
   data:
@@ -137,7 +137,7 @@ Read [SPIRE](./SPIRE.md) for further details.
 
 We support multiple TLS options both for ingress/egress (north/south traffic) to the edge proxy, and between the sidecar proxies (east/west traffic) within the mesh. For ingress, we support mTLS or non-TLS. To do this, enable the following:
 
-``` yaml
+```yaml
 edge:
   enableTLS: true
   certPath: /etc/proxy/tls/edge
@@ -191,19 +191,23 @@ If you want to deploy a Helm chart for a single service without the entire servi
 ## Install
 
 ### Prepare Tiller
-Tiller requires permissions to run installations in the cluster.  Depending on your 
-setup and security requirements, these particular permissions will change.  Please see
-the [official Helm docs](https://helm.sh/docs/using_helm/#tiller-and-role-based-access-control) to prepare your 
-production setup, but we do provide highlights in our [Multi-tenant Helm guide](./Multi-tenant%20Helm.md). 
 
-For development deployments with MiniKube, you can skip these steps and proceed on.  Full Tiller access should be granted by default when installing with Minikube.
+Tiller requires permissions to run installations in the cluster. Depending on your
+setup and security requirements, these particular permissions will change. Please see
+the [official Helm docs](https://helm.sh/docs/using_helm/#tiller-and-role-based-access-control) to prepare your
+production setup, but we do provide highlights in our [Multi-tenant Helm guide](./Multi-tenant%20Helm.md).
 
-For a quick setup, giving Tiller full cluster-wide access, have an admin apply the `helm-service-account.yaml` found in this repository.  This will enable Tiller 
-to act and install across the entire kubernetes cluster. 
+For development deployments with Minikube, you can skip these steps and proceed on. Full Tiller access should be granted by default when installing with Minikube.
+
+For a quick setup, giving Tiller full cluster-wide access, have an admin apply the `helm-service-account.yaml` found in this repository. This will enable Tiller
+to act and install across the entire kubernetes cluster.
+
 ```
 kubectl apply -f ./helm-service-account.yaml
 ```
+
 You'll then be able to initialize helm using this account:
+
 ```
 helm init --service-account tiller
 ```

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -1,4 +1,3 @@
-
 # Getting Started
 
 - [Getting Started](#getting-started)
@@ -192,8 +191,22 @@ If you want to deploy a Helm chart for a single service without the entire servi
 ## Install
 
 ### Prepare Tiller
+Tiller requires permissions to run installations in the cluster.  Depending on your 
+setup and security requirements, these particular permissions will change.  Please see
+the [official Helm docs](https://helm.sh/docs/using_helm/#tiller-and-role-based-access-control) to prepare your 
+production setup, but we do provide highlights in our [Multi-tenant Helm guide](./Multi-tenant%20Helm.md). 
 
-For production deployments of multi-tenant clusters we highly recommend that you setup Tiller following our [Multi-tenant Helm guide](./Multi-tenant%20Helm.md). If you're comfortable with providing Tiller with full cluster access then proceed onward. Full Tiller access should be granted when installing with Minikube.
+For development deployments with MiniKube, you can skip these steps and proceed on.  Full Tiller access should be granted by default when installing with Minikube.
+
+For a quick setup, giving Tiller full cluster-wide access, have an admin apply the `helm-service-account.yaml` found in this repository.  This will enable Tiller 
+to act and install across the entire kubernetes cluster. 
+```
+kubectl apply -f ./helm-service-account.yaml
+```
+You'll then be able to initialize helm using this account:
+```
+helm init --service-account tiller
+```
 
 ### Prepare Service Accounts
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -200,13 +200,19 @@ production setup, but we do provide highlights in our [Multi-tenant Helm guide](
 For development deployments with Minikube, you can skip these steps and proceed on. Full Tiller access should be granted by default when installing with Minikube.
 
 For a quick setup, giving Tiller full cluster-wide access, have an admin apply the `helm-service-account.yaml` found in this repository. This will enable Tiller
-to act and install across the entire kubernetes cluster.
+to act and install across the entire Kubernetes cluster.
 
+For Openshift:
+```
+oc apply -f ./helm-service-account.yaml
+```
+
+For Kubernetes:
 ```
 kubectl apply -f ./helm-service-account.yaml
 ```
 
-You'll then be able to initialize helm using this account:
+You'll then be able to initialize Helm using this account:
 
 ```
 helm init --service-account tiller

--- a/docs/Ingress.md
+++ b/docs/Ingress.md
@@ -46,4 +46,4 @@ To verify that Voyager has started, run:
   kubectl --namespace=kube-system get deployments -l "release=voyager-operator, app=voyager"
 ```
 
-Now you're all set. When you deploy the edge service, voyager-operator will create a custom `Ingress` resource which will provision a load balancer for you. You can run `kc get svc voyager-edge` to see the cluster ip and port.
+Now you're all set. When you deploy the edge service, voyager-operator will create a custom `Ingress` resource which will provision a load balancer for you. You can run `kubectl get svc voyager-edge` to see the cluster ip and port.

--- a/gm-control-api/json/special/domain.json
+++ b/gm-control-api/json/special/domain.json
@@ -1,7 +1,7 @@
 {
     "domain_key": "edge",
     "zone_key": "{{ .Values.gmControlApi.zone }}",
-    "name": {{ include "greymatter.domain" . | quote }},
+    "name": "*",
     "port": 8080,
     "redirects": null,
     "gzip_enabled": false,

--- a/gm-control-api/templates/gm-control-api.yaml
+++ b/gm-control-api/templates/gm-control-api.yaml
@@ -15,8 +15,7 @@ spec:
         app: {{ .Values.gmControlApi.name }}
         deployment: {{ .Values.gmControlApi.name }}
     spec:
-      {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
-      {{- else }}
+      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
       securityContext:
         runAsUser: 2000
         runAsGroup: 0

--- a/gm-control-api/templates/gm-control-api.yaml
+++ b/gm-control-api/templates/gm-control-api.yaml
@@ -15,6 +15,13 @@ spec:
         app: {{ .Values.gmControlApi.name }}
         deployment: {{ .Values.gmControlApi.name }}
     spec:
+      {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
+      {{- else }}
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 0
+        fsGroup: 2000
+      {{- end }}
       containers:
         - name: {{ .Values.gmControlApi.name }}
           image: {{ tpl .Values.gmControlApi.image $ }}

--- a/helm-service-account.yaml
+++ b/helm-service-account.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/slo/templates/postgres.yaml
+++ b/slo/templates/postgres.yaml
@@ -16,8 +16,7 @@ spec:
       labels:
         app: postgres-slo
     spec:
-      {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
-      {{- else }}
+      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
       securityContext:
         runAsUser: 2000
         runAsGroup: 0

--- a/slo/templates/postgres.yaml
+++ b/slo/templates/postgres.yaml
@@ -16,6 +16,13 @@ spec:
       labels:
         app: postgres-slo
     spec:
+      {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
+      {{- else }}
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 0
+        fsGroup: 2000
+      {{- end }}
       containers:
       - name: postgres
         {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
@@ -65,7 +72,7 @@ spec:
       {{- if .Values.postgres.private_image }}
       imagePullSecrets:
       - name: docker.secret
-      {{- end }}
+      {{- end }} 
       volumes:
       - name: postgres-slo
         persistentVolumeClaim:

--- a/slo/templates/slo.yaml
+++ b/slo/templates/slo.yaml
@@ -15,6 +15,13 @@ spec:
         app: slo
         deployment: slo
     spec:
+      {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
+      {{- else }}
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 0
+        fsGroup: 2000
+      {{- end }}
       serviceAccountName: {{ .Values.global.waiter.serviceAccount.name }}
       initContainers:
         - name: ensure-postgres

--- a/slo/templates/slo.yaml
+++ b/slo/templates/slo.yaml
@@ -15,8 +15,7 @@ spec:
         app: slo
         deployment: slo
     spec:
-      {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
-      {{- else }}
+      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
       securityContext:
         runAsUser: 2000
         runAsGroup: 0

--- a/slo/values.yaml
+++ b/slo/values.yaml
@@ -65,7 +65,7 @@ postgres:
   openshift:
     image: 'docker.io/centos/postgresql-10-centos7'
   k8s:
-    image: 'postgres:10'
+    image: 'docker.io/centos/postgresql-10-centos7'
   imagePullPolicy: IfNotPresent
   replica_count: 1
   #private_image: false


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR incorporates changes for deploying on bare Kubernetes (no openshift, minishift, minikube).  The main additions are:
- `securityContexts` to allow services with volume mounts to run properly.  
- modifying the edge `domain` to accept request with any HOST header keyword.  this allows port-forwarding (and may fix some CLI bugs people are hitting)
- makes the postgres image the same for k8s and openshift installations.  
- add a service account for tiller.  when starting completely from scratch, this does not already exist, and is not created by default as the instructions say happen in minishift.  

The main thing still an issue here is that the voyager ingress does not seem to be provisioned.  The dashboard can be seen with port-forwarding, a followup issue will be filed for voyager.  

Closes #268 
Closes #291 

<br/><br/>

2. What **changes to custom.yaml** are required?

I set data to not use s3, and gave prometheus lower CPU and MEM requirements to fit on my k8s cluster.  These are not required to see these changes depending on your setup.  

<br/><br/>

3. Have you documented any additional setup steps or configurations options?

Yes, the changes to the instructions are included in the diffs.  They're just to include the creation of the tiller service account, with enough generic verbiage to still work in the other environments.  Open to suggestions though.   
<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Full steps 0-100: no cluster at all to a working greymatter deployment.
```
eksctl create cluster --name prod --version 1.14 --nodegroup-name workers --node-type t3.medium --nodes=5 --nodes-min 1 --nodes-max 10 --node-ami auto --zones us-east-1a,us-east-1b --profile default
kubectl apply -f ./helm-service-account.yaml
helm init --service-account tiller
export PROVIDER=aws
helm repo add appscode https://charts.appscode.com/stable/
helm repo update
helm install appscode/voyager --name voyager-operator --version 10.0.0 \
  --namespace kube-system \
  --set cloudProvider=$PROVIDER \
  --set enableAnalytics=false \
  --set apiserver.enableAdmissionWebhook=false
helm repo add decipher https://nexus.production.deciphernow.com/repository/helm-hosted --username <username> --password '<password>'
helm repo update
helm dep up
helm install greymatter --namespace <project_namespace> --name <release_name> -f custom-greymatter.yaml -f custom-greymatter-secrets.yaml
```
<br/><br/>
