### PR TITLE
Adds the ability to rename the Postgres SSL CA, Cert and Key file names

### DIFF
--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -30,7 +30,7 @@ dependencies:
     alias: internal-jwt
 
   - name: slo
-    version: '2.0.4'
+    version: '2.0.5'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: gm-control-api

--- a/slo/Chart.yaml
+++ b/slo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.5.0
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
-version: 2.0.4
+version: 2.0.5
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/slo/templates/postgres-certs.yaml
+++ b/slo/templates/postgres-certs.yaml
@@ -12,9 +12,9 @@ metadata:
     heritage: "{{ $.Release.Service }}"
 type: Opaque
 data:
-  ca.pem: {{ .ca | b64enc }}
-  postgres.crt: {{ .cert | b64enc }}
-  postgres.key: {{ .key | b64enc }}
+  {{ .caName }}: {{ .ca | b64enc }}
+  {{ .certName }}: {{ .cert | b64enc }}
+  {{ .keyName }}: {{ .key | b64enc }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/slo/templates/postgres-slo-overrides.yaml
+++ b/slo/templates/postgres-slo-overrides.yaml
@@ -8,6 +8,6 @@ data:
     # These override configs in OpenShift's postgres container located at /var/lib/pgsql/data/userdata/postgresql.conf
     ssl = on
     hba_file = '{{ .Values.postgres.confMountPoint }}/pg_hba.conf'
-    ssl_cert_file = '{{ .Values.postgres.ssl.mountPoint }}/postgres.crt'
-    ssl_key_file = '{{ .Values.postgres.ssl.mountPoint }}/postgres.key'
-    ssl_ca_file = '{{ .Values.postgres.ssl.mountPoint }}/ca.pem'
+    ssl_cert_file = '{{ .Values.postgres.ssl.mountPoint }}/{{ .Values.postgres.ssl.certificates.certName }}'
+    ssl_key_file = '{{ .Values.postgres.ssl.mountPoint }}/{{ .Values.postgres.ssl.certificates.keyName }}'
+    ssl_ca_file = '{{ .Values.postgres.ssl.mountPoint }}/{{ .Values.postgres.ssl.certificates.caName }}'

--- a/slo/templates/slo.yaml
+++ b/slo/templates/slo.yaml
@@ -64,11 +64,11 @@ spec:
         - name: SSL_ENABLED
           value: {{ .Values.postgres.ssl.enabled | quote }}
         - name: SSL_SERVER_CA
-          value: {{ .Values.postgres.ssl.mountPoint}}/ca.pem
+          value: {{ .Values.postgres.ssl.mountPoint}}/{{ .Values.postgres.ssl.certificates.caName }}
         - name: SSL_SERVER_CERT
-          value: {{ .Values.postgres.ssl.mountPoint}}/postgres.crt
+          value: {{ .Values.postgres.ssl.mountPoint}}/{{ .Values.postgres.ssl.certificates.certName }}
         - name: SSL_SERVER_KEY
-          value: {{ .Values.postgres.ssl.mountPoint}}/postgres.key
+          value: {{ .Values.postgres.ssl.mountPoint}}/{{ .Values.postgres.ssl.certificates.keyName }}
         volumeMounts:
         - name: postgres-certs
           mountPath: {{ .Values.postgres.ssl.mountPoint | quote }}

--- a/slo/values.yaml
+++ b/slo/values.yaml
@@ -92,14 +92,20 @@ postgres:
     name: postgres-ssl-certs
     mountPoint: /certs
     certificates:
+      # This sets a default file name for the Postgres CA.  Can be overridden to change the filename
+      caName: ca.pem
       ca: |-
         -----BEGIN CERTIFICATE-----
         ...
         -----END CERTIFICATE-----
+      # This sets a default file name for the Postgres SSL Cert.  Can be overridden to change the filename
+      certName: server.crt
       cert: |-
         -----BEGIN CERTIFICATE-----
         ...
         -----END CERTIFICATE-----
+      # This sets a default file name for the Postgres SSL Key.  Can be overridden to change the filename
+      keyName: server.key
       key: |-
         -----BEGIN RSA PRIVATE KEY-----
         ...


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR allows a user to define the name of the Postgres SSL certs.  This is useful if a non DockerHub container is used that enforces that the SSL key be a specific name.

2. What **changes to custom.yaml** are required?

`caName`, `certName`, and `keyName` are all now viable options under `.Values.postgres.ssl.certificates`

3. Have you documented any additional setup steps or configurations options?

Comments are in the values.yaml file.  Defaults are configured to `ca.pem`, `server.crt`, and `server.key`

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

The code has been templated against DI2E and visual verification confirms the updates.
