### PR TITLE
Automation for minikube using make.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.tgz
 custom*.yaml
+credentials.yaml
 greymatter/charts
 charts.txt
 *.log

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,24 @@ install: dev-dep
 	@echo "installing greymatter helm charts"
 	helm install greymatter -f ./custom.yaml --name gm-deploy
 
+credentials:
+	./ci/scripts/build-credentials.sh
+
+fresh: credentials
+	minikube start -p gm-deploy --memory 6144 --cpus 6
+	helm init --wait
+	./ci/scripts/install-voyager.sh
+	helm install decipher/greymatter -f greymatter.yaml -f greymatter-secrets.yaml -f credentials.yaml -f greymatter-minikube.yaml -n gm
+
+minikube:
+	minikube start -p gm-deploy --memory 6144 --cpus 6
+	helm init --wait
+	./ci/scripts/install-voyager.sh
+	helm install decipher/greymatter -f greymatter.yaml -f greymatter-secrets.yaml -f credentials.yaml -f greymatter-minikube.yaml -n gm
+
+destroy:
+	minikube delete -p gm-deploy
+
 OUTPUT_PATH=./logs
 
 BN=$$(cat $(BUILD_NUMBER_FILE))

--- a/ci/scripts/build-credentials.sh
+++ b/ci/scripts/build-credentials.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd $(dirname "${BASH_SOURCE[0]}")
+echo decipher email: 
+read EMAIL
+echo password:
+read PASSWORD
+export EMAIL
+export PASSWORD
+envsubst < credentials.template > ../../credentials.yaml

--- a/ci/scripts/credentials.template
+++ b/ci/scripts/credentials.template
@@ -1,0 +1,5 @@
+dockerCredentials:
+  registry: docker.production.deciphernow.com
+  email: $EMAIL
+  username: $EMAIL
+  password: $PASSWORD

--- a/ci/scripts/install-voyager.sh
+++ b/ci/scripts/install-voyager.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+export PROVIDER=minikube
+helm repo add appscode https://charts.appscode.com/stable/
+helm repo update
+helm install appscode/voyager --name voyager-operator --version 10.0.0 \
+  --namespace kube-system \
+  --set cloudProvider=$PROVIDER \
+  --set enableAnalytics=false \
+  --set apiserver.enableAdmissionWebhook=false
+while [[ $(kubectl get pods -n kube-system -l app=voyager -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "waiting for pod" && sleep 10; done

--- a/docs/Deploy with Minikube.md
+++ b/docs/Deploy with Minikube.md
@@ -35,7 +35,7 @@ You will need the following tools installed (tested on both Mac OS and Linux Ubu
 
 ### Quickstart
 
-A couple of makefile targets provide a fast and easy way to standup greymatter on minikube.
+A couple of makefile targets provide a fast and easy way to standup Grey Matter on minikube.
 
 Before starting via Minikube you need to supply your credentials to dechipers docker registry. This will be your decipher email address and your decipher password.
 

--- a/docs/Deploy with Minikube.md
+++ b/docs/Deploy with Minikube.md
@@ -37,7 +37,7 @@ You will need the following tools installed (tested on both Mac OS and Linux Ubu
 
 A couple of makefile targets provide a fast and easy way to standup Grey Matter on minikube.
 
-Before starting via Minikube you need to supply your credentials to dechipers docker registry. This will be your decipher email address and your decipher password.
+Before starting via Minikube you need to supply your credentials for Decipher's docker registry. This will be your decipher email address and your decipher password.
 
 You can interactively fillout your credentials with the credentials make target.
 

--- a/docs/Deploy with Minikube.md
+++ b/docs/Deploy with Minikube.md
@@ -63,6 +63,8 @@ To spin down minikube.
 make destroy
 ```
 
+If you don't have the `envsubst` command you can get it with the `gettext` package on Mac or Ubuntu. The command is required for using `make credentials`.
+
 ### Start Minikube
 
 To launch a Minikube cluster to a `gm-deploy` VM profile, run the following command:

--- a/docs/Deploy with Minikube.md
+++ b/docs/Deploy with Minikube.md
@@ -56,7 +56,7 @@ To spin down minikube.
 ```sh
 make destroy
 ```
-Additionally there is the fresh makefile target. Which effectively runs make credentials and then make minikube.
+Additionally, there is the `fresh` makefile target that runs `make credentials` and `make minikube`.
 
 ```sh
 make fresh

--- a/docs/Deploy with Minikube.md
+++ b/docs/Deploy with Minikube.md
@@ -39,8 +39,14 @@ A couple of makefile targets provide a fast and easy way to standup Grey Matter 
 
 Before starting via Minikube you need to supply your credentials for Decipher's docker registry. This will be your decipher email address and your decipher password.
 
-You can interactively fillout your credentials with the credentials make target.
 
+The `fresh` makefile target runs `make credentials` and `make minikube`.
+
+```sh
+make fresh
+```
+
+You can interactively fillout your credentials with the credentials make target.
 ```sh
 make credentials
 ```
@@ -55,11 +61,6 @@ To spin down minikube.
 
 ```sh
 make destroy
-```
-Additionally, there is the `fresh` makefile target that runs `make credentials` and `make minikube`.
-
-```sh
-make fresh
 ```
 
 ### Start Minikube

--- a/docs/Deploy with Minikube.md
+++ b/docs/Deploy with Minikube.md
@@ -33,6 +33,35 @@ You will need the following tools installed (tested on both Mac OS and Linux Ubu
 - [helm](https://github.com/helm/helm/releases/tag/v2.14.3)@2.14.3
 - [virtualbox](https://www.virtualbox.org/wiki/Downloads)@6.0.12
 
+### Quickstart
+
+A couple of makefile targets provide a fast and easy way to standup greymatter on minikube.
+
+Before starting via Minikube you need to supply your credentials to dechipers docker registry. This will be your decipher email address and your decipher password.
+
+You can interactively fillout your credentials with the credentials make target.
+
+```sh
+make credentials
+```
+
+After you have filled out your credentials using the above target you can get minikube up and running in one target using:
+
+```sh
+make minikube
+```
+
+To spin down minikube.
+
+```sh
+make destroy
+```
+Additionally there is the fresh makefile target. Which effectively runs make credentials and then make minikube.
+
+```sh
+make fresh
+```
+
 ### Start Minikube
 
 To launch a Minikube cluster to a `gm-deploy` VM profile, run the following command:


### PR DESCRIPTION
1. No related issue.

<br/><br/>

2. What **changes to custom.yaml** are required? None

<br/><br/>

3. Have you documented any additional setup steps or configurations options? Yes in Deploy Minikube.

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. 

```
nicholas@daily:~/Documents/helm-charts$ make minikube
minikube start -p gm-deploy --memory 6144 --cpus 6
* [gm-deploy] minikube v1.3.1 on Ubuntu 18.04
* Creating kvm2 VM (CPUs=6, Memory=6144MB, Disk=20000MB) ...
* Preparing Kubernetes v1.15.2 on Docker 18.09.8 ...
* Pulling images ...
* Launching Kubernetes ...
* Waiting for: apiserver proxy etcd scheduler controller dns
* Done! kubectl is now configured to use "gm-deploy"
helm init --wait
$HELM_HOME has been configured at /home/nicholas/.helm.

Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.

Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy.
To prevent this, run `helm init` with the --tiller-tls-verify flag.
For more information on securing your installation see: https://docs.helm.sh/using_helm/#securing-your-helm-installation
./ci/scripts/install-voyager.sh
"appscode" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "decipher" chart repository
...Successfully got an update from the "appscode" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete.
NAME:   voyager-operator
LAST DEPLOYED: Fri Oct 18 13:58:30 2019
NAMESPACE: kube-system
STATUS: DEPLOYED

RESOURCES:
==> v1/ClusterRole
NAME                      AGE
voyager-voyager-operator  6s

==> v1/ClusterRoleBinding
NAME                                               AGE
voyager-voyager-operator                           6s
voyager-voyager-operator-apiserver-auth-delegator  6s

==> v1/Deployment
NAME                      READY  UP-TO-DATE  AVAILABLE  AGE
voyager-voyager-operator  0/1    1           0          6s

==> v1/Pod(related)
NAME                                       READY  STATUS   RESTARTS  AGE
voyager-voyager-operator-6665899bd9-n8cnl  0/1    Running  0         6s

==> v1/RoleBinding
NAME                                                                       AGE
voyager-voyager-operator-apiserver-extension-server-authentication-reader  6s

==> v1/Secret
NAME                                     TYPE    DATA  AGE
voyager-voyager-operator-apiserver-cert  Opaque  2     6s

==> v1/Service
NAME                      TYPE       CLUSTER-IP    EXTERNAL-IP  PORT(S)            AGE
voyager-voyager-operator  ClusterIP  10.97.173.61  <none>       443/TCP,56791/TCP  6s

==> v1/ServiceAccount
NAME                      SECRETS  AGE
voyager-voyager-operator  1        6s

==> v1beta1/APIService
NAME                                    AGE
v1beta1.admission.voyager.appscode.com  6s


NOTES:
Set cloudProvider for installing Voyager

To verify that Voyager has started, run:

  kubectl --namespace=kube-system get deployments -l "release=voyager-operator, app=voyager"

waiting for pod
helm install decipher/greymatter -f greymatter.yaml -f greymatter-secrets.yaml -f credentials.yaml -f greymatter-minikube.yaml -n gm
NAME:   gm
LAST DEPLOYED: Fri Oct 18 13:58:48 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/ClusterRole
NAME             AGE
control-sa-role  2s

==> v1/ClusterRoleBinding
NAME                    AGE
control-sa-rolebinding  2s

==> v1/ConfigMap
NAME                                       DATA  AGE
bootstrap-script                           1     2s
catalog-bootstrap-script                   1     2s
catalog-zone-bootstrap                     1     2s
data-mongo-init                            1     2s
domain-config                              2     2s
edge-catalog-mesh-config                   4     2s
edge-dashboard-mesh-config                 4     2s
edge-data-internal-mesh-config             4     2s
edge-data-mesh-config                      4     2s
edge-gm-control-api-mesh-config            4     2s
edge-internal-jwt-security-mesh-config     4     2s
edge-jwt-security-mesh-config              4     2s
edge-prometheus-mesh-config                4     2s
edge-slo-mesh-config                       4     2s
internal-data-mongo-init                   1     2s
internal-jwt-users                         1     2s
jwt-users                                  1     2s
postgres-slo-config                        1     2s
postgres-slo-overrides                     1     2s
prometheus                                 2     2s
service-catalog-catalog-api-config         1     2s
service-catalog-mesh-config                6     2s
service-dashboard-catalog-api-config       1     2s
service-dashboard-mesh-config              6     2s
service-data-catalog-api-config            1     2s
service-data-internal-mesh-config          6     2s
service-data-mesh-config                   6     2s
service-edge-catalog-api-config            1     2s
service-gm-control-api-catalog-api-config  1     2s
service-gm-control-api-mesh-config         6     2s
service-internal-jwt-security-mesh-config  6     2s
service-jwt-security-catalog-api-config    1     2s
service-jwt-security-mesh-config           6     2s
service-prometheus-mesh-config             6     2s
service-slo-catalog-api-config             1     2s
service-slo-mesh-config                    6     2s
special-mesh-config                        13    2s

==> v1/Deployment
NAME            READY  UP-TO-DATE  AVAILABLE  AGE
control         0/1    1           0          1s
dashboard       0/1    1           0          1s
data            0/1    1           0          1s
data-internal   0/1    0           0          1s
gm-control-api  0/1    0           0          1s
slo             0/1    0           0          1s

==> v1/Job
NAME                 COMPLETIONS  DURATION  AGE
catalog-init         0/1          1s        1s
gm-control-api-init  0/1          1s        1s

==> v1/PersistentVolumeClaim
NAME                STATUS   VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS  AGE
data-internal-pvc   Pending  standard                                  2s
gm-control-api-pvc  Pending  standard                                  2s
postgres-slo        Pending  standard                                  2s
prometheus          Bound    pvc-a91f41bc-9e75-42e4-b329-13c69ec4126b  40Gi  RWO  standard  2s

==> v1/Pod(related)
NAME                                    READY  STATUS    RESTARTS  AGE
catalog-68b87b9f97-25cm6                0/2    Init:0/1  0         1s
catalog-init-qkjx6                      0/1    Pending   0         1s
control-86b6796f98-794tp                0/1    Init:0/1  0         1s
dashboard-7df58b756-lgd5k               0/2    Pending   0         1s
data-5b9cd57d7c-mzjnx                   0/2    Pending   0         1s
data-internal-79c6d5dd86-rgchv          0/2    Pending   0         1s
data-mongo-0                            0/1    Pending   0         1s
edge-69c5c7b6b5-75526                   0/1    Pending   0         1s
gm-control-api-78bc579fb5-j64qw         0/2    Pending   0         1s
gm-control-api-init-7q69z               0/1    Pending   0         1s
internal-data-mongo-0                   0/1    Pending   0         1s
internal-jwt-security-847bdc5cb6-nj5xn  0/2    Pending   0         1s
internal-redis-564b47c857-7nd2t         0/1    Pending   0         1s
jwt-security-789c5db95c-kpvgx           0/2    Pending   0         1s
postgres-slo-0                          0/1    Pending   0         1s
prometheus-6c6755c8d7-msfrk             0/2    Pending   0         1s
redis-57f7659bc7-4qcfz                  0/1    Pending   0         0s

==> v1/Role
NAME            AGE
waiter-sa-role  2s

==> v1/RoleBinding
NAME                   AGE
waiter-sa-rolebinding  2s

==> v1/Secret
NAME                          TYPE                            DATA  AGE
data-internal-secrets         Opaque                          5     2s
data-secrets                  Opaque                          5     2s
docker.secret                 kubernetes.io/dockerconfigjson  1     2s
edge                          Opaque                          6     2s
internal-jwt-certs            Opaque                          6     2s
internal-jwt-security-secret  Opaque                          3     2s
internal-mongo-credentials    Opaque                          4     2s
internal-redis-password       Opaque                          1     2s
jwt-certs                     Opaque                          6     2s
jwt-security                  Opaque                          3     2s
mongo-credentials             Opaque                          4     2s
postgres-credentials          Opaque                          3     2s
postgres-ssl-certs            Opaque                          3     2s
redis-password                Opaque                          1     2s
sidecar-certs                 Opaque                          6     2s

==> v1/Service
NAME                 TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)            AGE
catalog              ClusterIP  10.101.8.112    <none>       9080/TCP           2s
control              ClusterIP  10.106.181.142  <none>       50000/TCP          2s
data-mongo           ClusterIP  None            <none>       27017/TCP          2s
edge                 ClusterIP  10.98.158.234   <none>       8080/TCP,8081/TCP  2s
gm-control-api       ClusterIP  10.105.234.246  <none>       5555/TCP           1s
internal-data-mongo  ClusterIP  None            <none>       27017/TCP          1s
internal-redis       ClusterIP  None            <none>       6379/TCP           1s
postgres-slo         ClusterIP  None            <none>       5432/TCP           1s
redis                ClusterIP  None            <none>       6379/TCP           1s

==> v1/ServiceAccount
NAME        SECRETS  AGE
control-sa  1        2s
waiter-sa   1        2s

==> v1/StatefulSet
NAME                 READY  AGE
data-mongo           0/1    1s
internal-data-mongo  0/1    1s
postgres-slo         0/1    1s

==> v1beta1/Deployment
NAME                   READY  UP-TO-DATE  AVAILABLE  AGE
catalog                0/1    1           0          1s
edge                   0/1    0           0          1s
internal-jwt-security  0/1    0           0          1s
internal-redis         0/1    0           0          1s
jwt-security           0/1    0           0          1s
prometheus             0/1    1           0          1s
redis                  0/1    0           0          1s

==> v1beta1/Ingress
NAME  AGE
edge  1s


NOTES:
Grey Matter 2.0.4 has been installed.

gm deployed to namespace "default" at 05:58:53 on 10/18/05


NOTE: It may take a few minutes for the installation to become stable.
    You can watch the status of the pods by running 'kubectl get pods -w -n default'
Once the environment has spun up you will be able to view Grey Matter's Dashboard at:
    https://*/services/dashboard/latest/

```
