### PR TITLE
Update from extensions/v1beta1 to apps/v1 + minor readme update

### DIFF
--- a/catalog/Chart.yaml
+++ b/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.2
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 2.0.4
+version: 2.0.5
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/catalog/templates/catalog.yaml
+++ b/catalog/templates/catalog.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: catalog
   namespace: {{ .Release.Namespace }}

--- a/dashboard/templates/prometheus.yaml
+++ b/dashboard/templates/prometheus.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}

--- a/docs/Deploy with Minikube.md
+++ b/docs/Deploy with Minikube.md
@@ -28,9 +28,9 @@ Minikube allows us to quicky setup a Kubernetes cluster and test drive Grey Matt
 
 You will need the following tools installed (tested on both Mac OS and Linux Ubuntu):
 
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)@1.15.3
-- [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)@1.3.1
-- [helm](https://github.com/helm/helm/releases/tag/v2.14.3)@2.14.3
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)@1.16.0
+- [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)@1.4.0
+- [helm](https://github.com/helm/helm/releases/tag/v2.14.3)@2.15.0
 - [virtualbox](https://www.virtualbox.org/wiki/Downloads)@6.0.12
 
 ### Quick Start
@@ -145,7 +145,7 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.3.1/miniku
 # Install Helm
 curl -LO https://git.io/get_helm.sh
 chmod 700 get_helm.sh
-./get_helm.sh --version v2.14.3
+./get_helm.sh --version v2.15.0
 
 # add helpful aliases
 alias minikube='sudo minikube'
@@ -226,7 +226,8 @@ helm install appscode/voyager --name voyager-operator --version 10.0.0 \
   --set cloudProvider=$PROVIDER \
   --set enableAnalytics=false \
   --set apiserver.enableAdmissionWebhook=false
-...
+```
+```sh
 NOTES:
 Set cloudProvider for installing Voyager
 
@@ -301,7 +302,7 @@ Then you can run the following commands to update the local charts and then inst
 
 ```sh
 helm dep up greymatter
-helm install greymatter -f custom-greymatter.yaml -f custom-greymatter-secrets.yaml -f custom-reymatter-minikube.yaml --name gm
+helm install greymatter -f custom-greymatter.yaml -f custom-greymatter-secrets.yaml -f custom-greymatter-minikube.yaml --name gm
 ```
 
 The `helm dep up greymatter` command will create a `./greymatter/charts` directory with tarballs of each sub-chart that the parent `greymatter` chart will use to install Grey Matter.

--- a/edge/templates/edge.yaml
+++ b/edge/templates/edge.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: edge
   namespace: {{ .Release.Namespace }}

--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: catalog
-    version: '2.0.4'
+    version: '2.0.5'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: data
@@ -21,11 +21,11 @@ dependencies:
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: jwt
-    version: '2.0.4'
+    version: '2.0.5'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: jwt
-    version: '2.0.4'
+    version: '2.0.5'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     alias: internal-jwt
 

--- a/jwt-gov/templates/jwt.yaml
+++ b/jwt-gov/templates/jwt.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
     name: {{ .Values.jwt.name | default "jwt-security"  }}
     namespace: {{ .Release.Namespace }}

--- a/jwt-gov/templates/redis.yaml
+++ b/jwt-gov/templates/redis.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   labels:
     app: {{ .Values.redis.name | default "redis" }}

--- a/jwt/Chart.yaml
+++ b/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 2.0.4
+version: 2.0.5
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/jwt/templates/jwt.yaml
+++ b/jwt/templates/jwt.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
     name: {{ .Values.jwt.name | default "jwt-security"  }}
     namespace: {{ .Release.Namespace }}

--- a/jwt/templates/redis.yaml
+++ b/jwt/templates/redis.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   labels:
     app: {{ .Values.redis.name | default "redis" }}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Kubernetes 1.16.0 deprecated several APIs that some Grey Matter charts are using.  These resources have been available at `apps/v1` for a long time, so this was just a matter of time before it broke.

resolves #276 

2. What **changes to custom.yaml** are required?

n/a

3. Have you documented any additional setup steps or configurations options?

none

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Stood up minikube and deployed the updated charts.  This was tested against k8s 1.16.0 and 1.11.10 (what OpenShift 3.11 is running)

**Output from k8s 1.16.0**
```console
➜  helm-charts git:(276_deployment_api) ✗ minikube start -p gm --memory 6144 --cpus 6 --vm-driver=hyperkit
```
```console
➜  helm-charts git:(276_deployment_api) ✗ kubectl get pods
NAME                                     READY   STATUS             RESTARTS   AGE
catalog-6f4d6df797-7z8k4                 2/2     Running            0          4m36s
catalog-init-dm2xt                       0/1     CrashLoopBackOff   4          4m35s
control-97bc599cb-zcpbz                  1/1     Running            0          4m36s
dashboard-8fc5446c6-d8rcj                2/2     Running            0          4m35s
data-7dccbcc645-999b7                    2/2     Running            0          4m35s
data-internal-7db6d98576-hd5s9           2/2     Running            0          4m36s
data-mongo-0                             1/1     Running            0          4m35s
edge-66d7c5847c-5m29z                    1/1     Running            0          4m36s
gm-control-api-fdb649c55-rtkjw           2/2     Running            0          4m36s
gm-control-api-init-p27jk                0/1     Completed          0          4m35s
internal-data-mongo-0                    1/1     Running            0          4m35s
internal-jwt-security-6ddd957976-pfmsw   2/2     Running            0          4m35s
internal-redis-56d95dc6b7-4kr9r          1/1     Running            0          4m36s
jwt-security-5cb6984499-htsn5            2/2     Running            0          4m36s
postgres-slo-0                           1/1     Running            0          4m36s
prometheus-54fb5d665f-fjg57              0/2     Pending            0          4m36s
redis-57c677dd7f-cdkrv                   1/1     Running            0          4m36s
slo-57df5975c8-m2wbk                     2/2     Running            0          4m36s
```

**Output from k8s 1.11.10**
```console
➜  helm-charts git:(276_deployment_api) ✗ minikube start -p gm1.11 --memory 6144 --cpus 6 --vm-driver=hyperkit --kubernetes-version='v1.11.10'
```
```console
➜  helm-charts git:(276_deployment_api) ✗ kubectl get pods
NAME                                     READY   STATUS      RESTARTS   AGE
catalog-578f76f848-656gr                 2/2     Running     0          2m
catalog-init-thmks                       0/1     Error       1          2m
control-55f9bf646c-xhrr2                 1/1     Running     0          2m
dashboard-fcddbcc9f-spjmx                2/2     Running     0          2m
data-7d64b86cd-s99xw                     2/2     Running     0          2m
data-internal-74568cf99-7f8f8            2/2     Running     0          2m
data-mongo-0                             1/1     Running     0          2m
edge-6bbd777946-krd57                    1/1     Running     0          2m
gm-control-api-55b6f96ccc-fscv8          2/2     Running     0          2m
gm-control-api-init-m97z4                0/1     Completed   0          2m
internal-data-mongo-0                    1/1     Running     0          2m
internal-jwt-security-68c45456b5-jvkp7   2/2     Running     2          2m
internal-redis-647bdd469d-5bz96          1/1     Running     0          2m
jwt-security-866bb874dd-7t42t            2/2     Running     2          2m
postgres-slo-0                           1/1     Running     0          2m
prometheus-55bcd7d97c-hbxrj              0/2     Pending     0          2m
redis-5cc4f5b8f4-lm4s6                   1/1     Running     0          2m
slo-f58b846b4-fgqwd                      2/2     Running     0          2m
voyager-edge-5d7d5954fc-22s72            1/1     Running     0          2m
```
