### PR TITLE
Update/add release to data names

### DIFF
--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.2.3
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 1.0.5
+version: 1.0.6
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/data/templates/NOTES.txt
+++ b/data/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Grey Matter Data {{ .Chart.AppVersion }} has been installed.
 
+Deployment: {{- .Release.Name }}
+
 NOTE: It may take a few minutes for the installation to become stable.
     {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
     You can watch the status of the pods by running 'oc get pods -w -n {{ .Release.Namespace }}

--- a/data/templates/_helpers.tpl
+++ b/data/templates/_helpers.tpl
@@ -15,7 +15,7 @@ Define the mongo host.
 {{- define "greymatter.mongo.address" -}}
 {{- $mongo := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.mongo.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "mongo-" . "mongo" $.Release.Namespace "svc.cluster.local:27017" | append $mongo.servers | set $mongo "servers" -}}
+{{- $noop := printf "%s%s-%d.%s-%s.%s.%s"  "mongo-" $.Release.Name . "mongo" $.Release.Name $.Release.Namespace "svc.cluster.local:27017" | append $mongo.servers | set $mongo "servers" -}}
 {{- end -}}
 {{- join "," $mongo.servers | quote -}}
 {{- end -}}

--- a/data/templates/data-secret.yaml
+++ b/data/templates/data-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.data.deploy.resources.data_secret.create }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -14,3 +15,4 @@ stringData:
 {{- end }}
 {{- end }}
   master_key: {{ .Values.data.master_key }}
+{{- end}}

--- a/data/templates/data.yaml
+++ b/data/templates/data.yaml
@@ -2,17 +2,17 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 #apiVersion: apps/v1
 metadata:
-  name: data
+  name: data-{{ .Release.Name | lower}}
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.data.replicas | default 1 }}
   selector:
     matchLabels:
-      app: data
+      app: data-{{ .Release.Name | lower}}
   template:
     metadata:
       labels:
-        app: data
+        app: data-{{ .Release.Name | lower}}
     spec:
       containers:
       - name: data
@@ -106,10 +106,10 @@ spec:
           - name: ZK_ANNOUNCE_PATH
             {{- if .Values.data.deploy.standalone }}
             {{- if .Values.data.deploy.base_path }}
-            value: {{ tpl .Values.data.deploy.base_path $ | trunc 3 | quote }}
+            value: {{ tpl .Values.data.deploy.base_path $ | quote }}
             {{- end }}
             {{- else }}
-            value: {{ tpl .Values.data.base_path $ | trunc 3 | quote }}
+            value: {{ tpl .Values.data.base_path $ | quote }}
             {{- end }}
           - name: TIMEOUT
             value: {{ .Values.sidecar.timeout | quote  }}
@@ -131,14 +131,14 @@ spec:
         - mountPath: /etc/proxy/tls/sidecar
           name: sidecar
       imagePullSecrets:
-      - name: docker.secret
+      - name: {{ if .Values.data.deploy.resources.docker_secret.create }}docker.secret{{else}}{{ .Values.data.deploy.resources.docker_secret.manual_name }}{{ end }}
       volumes:
       - name: sidecar
         secret:
           secretName: sidecar
       - name: data
         secret:
-          secretName: data
+          secretName: {{ if .Values.data.deploy.resources.data_secret.create }}data{{else}}{{ .Values.data.deploy.resources.data_secret.manual_name }}{{ end }}
       - name: jwt-security
         secret:
           secretName: jwt-security

--- a/data/templates/docker-secret.yaml
+++ b/data/templates/docker-secret.yaml
@@ -2,6 +2,7 @@
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.dockerCredentials.registry (printf "%s:%s" .Values.dockerCredentials.username .Values.dockerCredentials.password | b64enc) | b64enc }}
 {{- end }}
 {{- if .Values.data.deploy.standalone }}
+{{- if .Values.data.deploy.resources.docker_secret.create }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -10,4 +11,5 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}
 {{- end }}

--- a/data/templates/jwt-secret.yaml
+++ b/data/templates/jwt-secret.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.data.deploy.standalone }}
 {{- if .Values.data.deploy.secrets }}
+{{- if .Values.data.deploy.resources.jwt_secret.create }}
 {{- range $secrets := .Values.data.deploy.secrets }}
 ---
 apiVersion: v1
@@ -21,6 +22,7 @@ data:
   {{- end }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/data/templates/mongo-certs.yaml
+++ b/data/templates/mongo-certs.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.mongo.ssl.enabled }}
 {{ if .Values.mongo.ssl.certificates }}
+{{- if .Values.data.deploy.resources.mongo_certs.create }}
 {{- with .Values.mongo.ssl.certificates }}
 ---
 apiVersion: v1
@@ -22,5 +23,5 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
-
+{{- end }}
 

--- a/data/templates/mongo-configmap.yaml
+++ b/data/templates/mongo-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.data.deploy.resources.mongo_configmap.create }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -19,3 +20,4 @@ data:
         ],
     });
   {{- end }}
+{{- end }}

--- a/data/templates/mongo-passwords.yaml
+++ b/data/templates/mongo-passwords.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.data.deploy.resources.mongo_passwords.create }}
 {{ with .Values.mongo.credentials }}
 apiVersion: v1
 kind: Secret
@@ -13,4 +14,5 @@ stringData:
   root_password: {{ .root_password }}
   admin_password: {{ .admin_password }}
   database: {{ .database }}
+{{- end }}
 {{- end }}

--- a/data/templates/mongo-service.yaml
+++ b/data/templates/mongo-service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: mongo
+  name: mongo-{{ .Release.Name | lower}}
   namespace: {{ .Release.Namespace }}
 spec:
   clusterIP: None
@@ -11,6 +11,6 @@ spec:
       protocol: TCP
       targetPort: 27017
   selector:
-    app: mongo
+    app: mongo-{{ .Release.Name | lower}}
   sessionAffinity: None
   type: ClusterIP

--- a/data/templates/mongo.yaml
+++ b/data/templates/mongo.yaml
@@ -2,20 +2,20 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   labels:
-    app: mongo
-  name: mongo
+    app: mongo-{{ .Release.Name | lower}}
+  name: mongo-{{ .Release.Name | lower}}
   namespace: {{ .Release.Namespace }}
 spec:
   podManagementPolicy: Parallel
   replicas: {{ .Values.mongo.replicas }}
   selector:
     matchLabels:
-      app: mongo
-  serviceName: mongo
+      app: mongo-{{ .Release.Name | lower}}
+  serviceName: mongo-{{ .Release.Name | lower}}
   template:
     metadata:
       labels:
-        app: mongo
+        app: mongo-{{ .Release.Name | lower}}
     spec:
       containers:
       - env:
@@ -49,7 +49,7 @@ spec:
           protocol: TCP
         volumeMounts:
         - mountPath: /var/lib/mongodb/data
-          name: data
+          name: data-{{ .Release.Name | lower}}
         - mountPath: /docker-entrypoint-initdb.d/
           name: mongo-init
         {{- if .Values.mongo.ssl.enabled }}
@@ -59,19 +59,19 @@ spec:
       volumes:
         - name: mongo-init
           configMap:
-            name: mongo-init
+            name: {{ if .Values.data.deploy.resources.mongo_configmap.create }}mongo-init{{else}}{{ .Values.data.deploy.resources.mongo_configmap.manual_name }}{{ end }}
         {{- if .Values.mongo.ssl.enabled }}
         - name: certificates
           secret:
-            secretName: {{ .Values.mongo.ssl.name }}
+            secretName: {{ if .Values.data.deploy.resources.mongo_certs.create }}{{ .Values.mongo.ssl.name }}{{else}}{{ .Values.data.deploy.resources.mongo_certs.manual_name }}{{ end }}
         {{- end }}
       {{- if .Values.mongo.private_image }}
       imagePullSecrets:
-      - name: docker.secret
+      - name: {{ if .Values.data.deploy.resources.docker_secret.create }}docker.secret{{else}}{{ .Values.data.deploy.resources.docker_secret.manual_name }}{{ end }}
       {{- end }}
   volumeClaimTemplates:
   - metadata:
-      name: data
+      name: data-{{ .Release.Name | lower}}
     spec:
       accessModes:
         - ReadWriteOnce

--- a/data/values.yaml
+++ b/data/values.yaml
@@ -17,9 +17,10 @@ data:
   version: 0.2.3
   client_jwt_endpoint_address: localhost
   client_jwt_endpoint_use_tls: 'true'
-  base_path: /services/{{ $.Values.data.name | lower }}/{{ $.Values.data.version }}
+  base_path: /services/{{ $.Values.data.name | lower }}/{{ $.Values.data.version | trunc 3 }}
   image: docker.production.deciphernow.com/deciphernow/gm-data:{{ $.Values.data.version }}
   standalone_image:
+  replicas: 1
   certs_mount_point: /certs
   imagePullPolicy: Always
   use_tls: true
@@ -45,6 +46,32 @@ data:
         server.cert.pem:
         server.key.pem:
         server.trust.pem:
+
+    # To specify a resource name insteard of creating one set create to false and define a manual_name
+    # During a standalone deployment some resources may be present in the namespace already.  In that case
+    # you can avoid creating the resource (create: false) and instead point the chart to that resource 
+    # with `manual_name`. (mongo_configmap.manual_name is not used because the password secret is passed
+    # in via envar and internally defined as mongo-credentials)
+    resources:
+      data_secret:
+        create: true
+        manual_name: ""
+      docker_secret:
+        create: true
+        manual_name: ""
+      mongo_certs:
+        create: true
+        manual_name: ""
+      mongo_configmap:
+        create: true
+        manual_name: ""
+      mongo_passwords:
+        create: true
+        # manual_name: "mongo-credentials"
+      jwt_secret:
+        create: false
+        manual_name: ""
+
 
   # These are the AWS settings that Data requires if configured to use S3
   #  - bucket: The name of the bucket where Data will write it's shared config, if configured

--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   repository: "https://nexus.production.deciphernow.com/repository/helm-hosted"
 
 - name: data
-  version: "1.0.5"
+  version: "1.0.6"
   repository: "https://nexus.production.deciphernow.com/repository/helm-hosted"
 
 - name: dashboard


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

updates the data chart so that a user can specify not to create resources when installing.   This PR also adds the release name to the name of resources created to allow for multiple deployments of data in a single namespace.

2. What **changes to custom.yaml** are required?

No changes to custom.yaml file when deploying the full greymatter suite.  when deploying standalone data you can use these values to avoid the additional creation of undesired resources.
```
    # To specify a resource name insteard of creating one set create to false and define a manual_name
    # During a standalone deployment some resources may be present in the namespace already.  In that case
    # you can avoid creating the resource (create: false) and instead point the chart to that resource 
    # with `manual_name`. (mongo_configmap.manual_name is not used because the password secret is passed
    # in via envar and internally defined as mongo-credentials)
    resources:
      data_secret:
        create: true
        manual_name: ""
      docker_secret:
        create: true
        manual_name: ""
      mongo_certs:
        create: true
        manual_name: ""
      mongo_configmap:
        create: true
        manual_name: ""
      mongo_passwords:
        create: true
        # manual_name: "mongo-credentials"
      jwt_secret:
        create: false
        manual_name: ""
```

3. Have you documented any additional setup steps or configurations options?

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Jenkins passes.  I've deployed the full gm suite as well as a standalone into the development cluster successfully.
