### PR TITLE
removed endpoint url note in greymatter/templates/NOTES.txt

### DIFF
--- a/greymatter/templates/NOTES.txt
+++ b/greymatter/templates/NOTES.txt
@@ -10,9 +10,4 @@ NOTE: It may take a few minutes for the installation to become stable.
     You can watch the status of the pods by running 'kubectl get pods -w -n {{ .Release.Namespace }}'
     {{- end }}
 
-{{- if .Values.global }}
-Once the environment has spun up you will be able to view Grey Matter's Dashboard at:
-    https://{{ include "greymatter.domain" . }}/services/dashboard/latest/
-{{- end }}
-        
         


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

```
Once the environment has spun up you will be able to view Grey Matter's Dashboard at:
    https://greymatter.default.staging.deciphernow.com/services/dashboard/latest/
```
is no longer accurate or valid for most deployments see [initial comment](https://github.com/DecipherNow/helm-charts/pull/341#pullrequestreview-305405421)

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

none needed

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

new output
```bash
david@david-Oryx-Pro:~/dev/work/helm-charts$ helm install greymatter -f greymatter.yaml -f greymatter-secrets.yaml  --name gm-deploy 
NAME:   gm-deploy
LAST DEPLOYED: Tue Oct 22 15:33:03 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/ClusterRole
NAME             AGE
control-sa-role  1s

==> v1/ClusterRoleBinding
NAME                    AGE
control-sa-rolebinding  1s

==> v1/ConfigMap
NAME                                       DATA  AGE
bootstrap-script                           1     2s
catalog-bootstrap-script                   1     2s
catalog-zone-bootstrap                     1     2s
data-mongo-init                            1     2s
domain-config                              2     2s
edge-catalog-mesh-config                   4     2s
edge-dashboard-mesh-config                 4     2s
edge-data-internal-mesh-config             4     2s
edge-data-mesh-config                      4     2s
edge-gm-control-api-mesh-config            4     2s
edge-internal-jwt-security-mesh-config     4     2s
edge-jwt-security-mesh-config              4     2s
edge-prometheus-mesh-config                4     2s
edge-slo-mesh-config                       4     2s
internal-data-mongo-init                   1     2s
internal-jwt-users                         1     2s
jwt-users                                  1     2s
postgres-slo-config                        1     2s
postgres-slo-overrides                     1     2s
prometheus                                 2     2s
service-catalog-catalog-api-config         1     2s
service-catalog-mesh-config                6     2s
service-dashboard-catalog-api-config       1     2s
service-dashboard-mesh-config              6     2s
service-data-catalog-api-config            1     2s
service-data-internal-mesh-config          6     2s
service-data-mesh-config                   6     2s
service-edge-catalog-api-config            1     2s
service-gm-control-api-catalog-api-config  1     2s
service-gm-control-api-mesh-config         6     2s
service-internal-jwt-security-mesh-config  6     2s
service-jwt-security-catalog-api-config    1     2s
service-jwt-security-mesh-config           6     2s
service-prometheus-mesh-config             6     2s
service-slo-catalog-api-config             1     2s
service-slo-mesh-config                    6     2s
special-mesh-config                        13    2s

==> v1/Deployment
NAME            READY  UP-TO-DATE  AVAILABLE  AGE
control         0/1    1           0          1s
dashboard       0/1    1           0          1s
data            0/1    0           0          1s
data-internal   0/1    0           0          1s
gm-control-api  0/1    0           0          1s
slo             0/1    0           0          1s

==> v1/Job
NAME                 COMPLETIONS  DURATION  AGE
catalog-init         0/1          1s        1s
gm-control-api-init  0/1          1s        1s

==> v1/PersistentVolumeClaim
NAME                STATUS   VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS  AGE
data-internal-pvc   Bound    pvc-c7aa6fd3-f502-11e9-9b30-0e1dcc28ffde  40Gi      RWO           gp2           1s
gm-control-api-pvc  Bound    pvc-c7a98fae-f502-11e9-9b30-0e1dcc28ffde  1Gi       RWO           gp2           1s
postgres-slo        Bound    pvc-c7ab573e-f502-11e9-9b30-0e1dcc28ffde  8Gi       RWO           gp2           1s
prometheus          Pending  gp2                                       2s

==> v1/Pod(related)
NAME                                    READY  STATUS             RESTARTS  AGE
catalog-559bbff8f8-489d8                0/2    Init:0/1           0         1s
catalog-init-9qrtk                      0/1    Pending            0         1s
control-7964d856cd-xcmhh                0/1    Init:0/1           0         1s
dashboard-75ddb865bd-9lqx8              0/2    ContainerCreating  0         1s
data-7c867bdbb5-dcd4x                   0/2    Pending            0         1s
data-internal-57479c8994-xw79b          0/2    Pending            0         1s
data-mongo-0                            0/1    ContainerCreating  0         1s
edge-56cdb9c557-x4pwj                   0/1    ContainerCreating  0         1s
gm-control-api-5ffddb4fdc-qklk6         0/2    Pending            0         1s
gm-control-api-init-4wvbb               0/1    Pending            0         1s
internal-data-mongo-0                   0/1    Pending            0         1s
internal-jwt-security-6957bc6c4c-l7xcc  0/2    Pending            0         1s
internal-redis-95cf8857b-vr8zz          0/1    ContainerCreating  0         1s
jwt-security-569cdd5c74-488bm           0/2    Pending            0         1s
postgres-slo-0                          0/1    Pending            0         1s
prometheus-6865c99cf-v8jc9              0/2    Pending            0         1s
redis-578d5db45b-c979f                  0/1    Pending            0         0s
slo-7f96b49846-7vwtm                    0/2    Pending            0         0s

==> v1/Role
NAME            AGE
waiter-sa-role  1s

==> v1/RoleBinding
NAME                   AGE
waiter-sa-rolebinding  1s

==> v1/Secret
NAME                          TYPE                            DATA  AGE
data-internal-secrets         Opaque                          5     2s
data-secrets                  Opaque                          5     2s
docker.secret                 kubernetes.io/dockerconfigjson  1     2s
edge                          Opaque                          6     2s
internal-jwt-certs            Opaque                          6     2s
internal-jwt-security-secret  Opaque                          3     2s
internal-mongo-credentials    Opaque                          4     2s
internal-redis-password       Opaque                          1     2s
jwt-certs                     Opaque                          6     2s
jwt-security                  Opaque                          3     2s
mongo-credentials             Opaque                          4     2s
postgres-credentials          Opaque                          3     2s
postgres-ssl-certs            Opaque                          3     2s
redis-password                Opaque                          1     2s
sidecar-certs                 Opaque                          6     2s

==> v1/Service
NAME                 TYPE       CLUSTER-IP      EXTERNAL-IP  PORT(S)            AGE
catalog              ClusterIP  10.100.109.142  <none>       9080/TCP           1s
control              ClusterIP  10.100.104.159  <none>       50000/TCP          1s
data-mongo           ClusterIP  None            <none>       27017/TCP          1s
edge                 ClusterIP  10.100.51.184   <none>       8080/TCP,8081/TCP  1s
gm-control-api       ClusterIP  10.100.151.44   <none>       5555/TCP           1s
internal-data-mongo  ClusterIP  None            <none>       27017/TCP          1s
internal-redis       ClusterIP  None            <none>       6379/TCP           1s
postgres-slo         ClusterIP  None            <none>       5432/TCP           1s
redis                ClusterIP  None            <none>       6379/TCP           1s

==> v1/ServiceAccount
NAME        SECRETS  AGE
control-sa  1        1s
waiter-sa   1        1s

==> v1/StatefulSet
NAME                 READY  AGE
data-mongo           0/1    1s
internal-data-mongo  0/1    1s
postgres-slo         0/1    1s

==> v1beta1/Deployment
NAME                   READY  UP-TO-DATE  AVAILABLE  AGE
catalog                0/1    1           0          1s
edge                   0/1    1           0          1s
internal-jwt-security  0/1    0           0          1s
internal-redis         0/1    0           0          1s
jwt-security           0/1    0           0          1s
prometheus             0/1    1           0          1s
redis                  0/1    0           0          1s

==> v1beta1/Ingress
NAME  AGE
edge  1s


NOTES:
Grey Matter 2.0.4 has been installed.

gm-deploy deployed to namespace "default" at 07:33:09 on 10/22/07


NOTE: It may take a few minutes for the installation to become stable.
    You can watch the status of the pods by running 'kubectl get pods -w -n default'

        
```
