### PR TITLE
bring credentials to greymatter-secrets so users know they exist

### DIFF
--- a/greymatter-secrets.yaml
+++ b/greymatter-secrets.yaml
@@ -1,4 +1,3 @@
-
 dockerCredentials:
   registry: docker.production.deciphernow.com
   email:
@@ -13,437 +12,454 @@ data:
       region: us-east-1
       bucket: decipher-quickstart-helm
   mongo:
+    credentials:
+      # The credentials to be used to communicate with Mongo and the database to be created
+      root_username: 'mongo'
+      root_password: 'mongo'
+      database: 'gmdata'
+      admin_password: 'mongopassword'
     ssl:
       certificates:
-      - name: mongo-ssl-certs
-        ca: |-
-          -----BEGIN CERTIFICATE-----
-          MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT
-          MREwDwYDVQQIDAhWaXJnaW5pYTETMBEGA1UEBwwKQWxleGFuZHJpYTEkMCIGA1UE
-          CgwbRGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVl
-          cmluZzEuMCwGA1UEAwwlRGVjaXBoZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChS
-          b290KTEqMCgGCSqGSIb3DQEJARYbZW5naW5lZXJpbmdAZGVjaXBoZXJub3cuY29t
-          MB4XDTE3MDgwOTExMjMwOFoXDTI3MDgwNzExMjMwOFowgcAxCzAJBgNVBAYTAlVT
-          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
-          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
-          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
-          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wggIiMA0GCSqGSIb3
-          DQEBAQUAA4ICDwAwggIKAoICAQDPkxaiUD3uqR2AA5jwAb9gCjD+BrOrYBoelnR6
-          u29FPT5cHeM8bfVo6zixy7qC2lXzhK5gH/TLWXelpEwU+sw81oUbzZlB7Z2lvpj8
-          t4zXg4zgHNPqAFJM6L9b70dLgukhcUO6nnIiPPAprmtBDvXbtBwDCzOPaMcBeEwi
-          zERa4WyXYjn5Q+a8LTTLQ/OFmLHFA2dCG78s6cYQOfF92L641QdOhqXPtq+QwqAm
-          WkQ53Pes6rHmjT0kC8hEI5fCKEA3QXYt6YtgX+KIHgOYWI0g22wh95ohk+DuRL/O
-          3zzJ9tCjrMPO2lxmg0GdpuqjfR6K8CEk4Yq2dUwYC7dffgCrWv9zik/pXeoSvTv3
-          XprMN2WWKBX9lVC2qKFhNX4driBFRO0i5+bGdM1e8NilUDqHiikwhaVx2znb/E/b
-          LCCwlhC0oAAxnVZ1J18k46STe7hlg/RqM/18uxmhP9an2FkDtuyZBugbpWpgk7lE
-          tpOd92iCGYDc6k8Jsn+p0UiZjioJv/Gm04T3t90dkVu7D+mwFIsEAaJjwepEZ7ki
-          IBayWrJml+DT4ghyadkms8UaOa+YOYEZiY5GzJhEodAt01OanSkzR/FYjM4SuGXw
-          Rrq2p8hTuUBBm1p9ipv8DLqPmlXZ2Cn7ByTX7TMsG+77R4zkka5XD5tULpAf5xKo
-          qx4N/QIDAQABo2YwZDAdBgNVHQ4EFgQUbA2I9pZUJ7Z6WxXfTRecoCsqfnUwHwYD
-          VR0jBBgwFoAUY5U4Jb8hC6Ssinh2LzCB3tly8bcwEgYDVR0TAQH/BAgwBgEB/wIB
-          ADAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAHMtenslnEuvnT4g
-          JWR70FZv3wUOOqAsyxJdWj4o8yM7/V3wGKMxkRv7Oqetp92XYauffSPxE3INnGMq
-          DdRMTf2MGVnv/W5PJouZwMhBX4W6rjvl4QCSl+Q+wSt+OibNu2AxdCeQKa67cwvf
-          QfD4ufeWfvUPzazwzuJqE5WCjNnM2KsWbmzclquAbUjKH0017UGRYe8THrCZ5Mdn
-          L9X+ZSe5wWHWIm7JLn5nexeW668hgcdINrKBRg7ygKWrO/aMFnl3cQXmbNtXBt+y
-          E5tof618/HWJBjC3e+eyIMqjgjEZmxYfxwBTk0XVEZuA3PyAGigA17Q0ev5Zx4ii
-          2fGIYN5y3L6OMrfkcmdtihoQisqd+zKlgxWH4Z2KtV0RFVTreooNaSpFZu6EeCPH
-          0fg++TV/uGOEfNc4seEfFiaM4uq8mp5E1PYOXX4DLkzignqql9h8u3/3ZC7m4NoY
-          qpoOurQyY/dCUIJw3Kb+Dlck1OZsGQNvkpflHvCxCvTq48bEgjO+xkoYBODhY0wT
-          grl1kFBXMNNAiFiHlHaM6h+MKv/9cRi63KXmhiEjUWUVcdT9ZRRPJ6qd5QAJHJ+h
-          NU7s17ar5/4SgJx9BZSEYzQQCzt4REwBxfrF/GdGNia1wZcqMNylmkD8fCWBZiW2
-          sarsDzVzwvduL1ODIycXxe/pZUxi
-          -----END CERTIFICATE-----
-          -----BEGIN CERTIFICATE-----
-          MIIGgjCCBGqgAwIBAgIJAKBdlRUnXXIJMA0GCSqGSIb3DQEBCwUAMIHNMQswCQYD
-          VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
-          JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
-          RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
-          cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
-          bm93LmNvbTAeFw0xNzA4MDkxMTIyMTlaFw0yNzA4MDcxMTIyMTlaMIHNMQswCQYD
-          VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
-          JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
-          RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
-          cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
-          bm93LmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALDo08zRbssi
-          vrgIyCiE3x5ttHDcEsOs3EaZaE3hHpXK5an5iXT8/tl35BDAWl1J6CJkm4ip0Ch5
-          jOqrk5peQJKuN731GlafzoabwHcqyD6CvJZANre64s0J2CTZpob2gWM06C75uwzK
-          5W4JfivSzBpHu8A+FJARmZpnQoFDRIPWQFk9q22CPIWtlUdrkwVdnHlV++hRKKBU
-          qwAyXj6UUnrvwWNER0C0wksoJf+5oP/HLyqzUcd6yPmOiAe8QhR8jLdt/K8e14GI
-          7XhAytKxI2qHqzUmi2T57lIzz83fG4Cmo59mIF4jLvHfjC48zz9dCoObCK/QcczX
-          lipxmTm9HocDWCCo0L035arvWxRkP8ec75CE20Q8RqUY9jQo4a64RydbAabCw8s0
-          b0mSoHbRvpZCx96KhCG7EkjCorWrvh9dxZAenIZDAbn3sX9QGc6A+B5MYbv70UKo
-          8RD2IODsvuCSnn1rEQpGb0d6hNSReDN2cYLnSeuoMUlxT/SRCNBizGOWxJuFL1Cr
-          5YnNyUv3tCEXKxEM9OoRHutydmeg8fTbTu8hAlGiYhgqehmkApS25qCl4sVz3FUj
-          /y2yfQbecliu/YdPVziRGsLOTGhQldBSIaVdMGA/muzxVtOJdLBuK/qK/gvW7N2s
-          vZQTHZz+B10Dlxs9S2Nhf7FX7pMLM9hXAgMBAAGjYzBhMB0GA1UdDgQWBBRjlTgl
-          vyELpKyKeHYvMIHe2XLxtzAfBgNVHSMEGDAWgBRjlTglvyELpKyKeHYvMIHe2XLx
-          tzAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsF
-          AAOCAgEAcB4z4ALRX+s1Fb1j2sWLo65jIyxm0OB2RTlhstd4+zd+zFjLg7XE0O5j
-          Ilm3basVlLM2mTmi5CC4mvOBibSb6NlJr34GmKbfwYVLj3tpnlnA/HGGzHY3uoX6
-          zBUSIYRH10k2bmpM438fXtz9P+kHAkmsVj2Yk8uLg+tZDZEdM8qiWbaIZa+awHwL
-          DBhd1dQ7ZyejVJLKGyYwd7dMYLq04F4AqawPp2ksmcUtktU2Q+uGmJBkqgBzUTC+
-          64yPKBbPa2WFFDVtqt0r6qD2N7FD6v0b0PiBeruvhpSva1yvE0vMNfa9kc8ExrKz
-          7GMMGsv3TIOqK0tYXJayoM+8VAELwBcFvkCkobs4TtkF3VoPiO91hlm7K+7woNQH
-          OVhxqDqH3ECA7vNLeA09xT7EApXzPGwk163O4qoZdT7VUI2Fu9G0+IzzS42TVXOm
-          MUp1sEidUUElwuuqDvKxsBP6do9xT8dHg2n9Y04ME2FyQ1omuLzRrcyjU6Qo6PLr
-          H/di6KT3iiZ/leFkDMf5/Pesy7bExPZN2sHR3SpR5RwQh50T4KZx7FOqvCJpi6Pp
-          H1cz0921qGtG0iheOzWfonmvYKnhxcTTpg+fuiVdPWwdutjVl+HPc2yjw1Gdqw4h
-          n4oFjG4KQO6zvZzGDFay9HazZyUKpgamy24u8XY7/BSWc1c95Gg=
-          -----END CERTIFICATE-----
-        cert: |-
-          -----BEGIN CERTIFICATE-----
-          MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
-          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
-          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
-          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
-          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
-          MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
-          Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
-          RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
-          MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
-          AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
-          l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
-          uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
-          RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
-          dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
-          RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
-          BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
-          blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
-          6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
-          Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
-          EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
-          IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
-          ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
-          bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
-          BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
-          bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
-          dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
-          zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
-          Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
-          8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
-          IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
-          eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
-          cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
-          wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
-          dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
-          XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
-          fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
-          -----END CERTIFICATE-----
-        key: |-
-          -----BEGIN RSA PRIVATE KEY-----
-          MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
-          p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
-          biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
-          kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
-          JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
-          xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
-          UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
-          FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
-          AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
-          ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
-          pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
-          lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
-          fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
-          Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
-          SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
-          qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
-          Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
-          6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
-          keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
-          ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
-          HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
-          pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
-          vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
-          P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
-          zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
-          -----END RSA PRIVATE KEY-----
-        cert_key: |-
-          -----BEGIN CERTIFICATE-----
-          MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
-          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
-          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
-          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
-          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
-          MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
-          Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
-          RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
-          MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
-          AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
-          l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
-          uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
-          RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
-          dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
-          RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
-          BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
-          blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
-          6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
-          Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
-          EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
-          IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
-          ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
-          bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
-          BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
-          bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
-          dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
-          zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
-          Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
-          8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
-          IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
-          eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
-          cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
-          wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
-          dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
-          XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
-          fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
-          -----END CERTIFICATE-----
-          -----BEGIN RSA PRIVATE KEY-----
-          MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
-          p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
-          biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
-          kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
-          JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
-          xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
-          UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
-          FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
-          AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
-          ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
-          pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
-          lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
-          fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
-          Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
-          SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
-          qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
-          Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
-          6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
-          keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
-          ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
-          HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
-          pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
-          vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
-          P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
-          zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
-          -----END RSA PRIVATE KEY-----
+        - name: mongo-ssl-certs
+          ca: |-
+            -----BEGIN CERTIFICATE-----
+            MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT
+            MREwDwYDVQQIDAhWaXJnaW5pYTETMBEGA1UEBwwKQWxleGFuZHJpYTEkMCIGA1UE
+            CgwbRGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVl
+            cmluZzEuMCwGA1UEAwwlRGVjaXBoZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChS
+            b290KTEqMCgGCSqGSIb3DQEJARYbZW5naW5lZXJpbmdAZGVjaXBoZXJub3cuY29t
+            MB4XDTE3MDgwOTExMjMwOFoXDTI3MDgwNzExMjMwOFowgcAxCzAJBgNVBAYTAlVT
+            MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+            eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+            ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+            hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wggIiMA0GCSqGSIb3
+            DQEBAQUAA4ICDwAwggIKAoICAQDPkxaiUD3uqR2AA5jwAb9gCjD+BrOrYBoelnR6
+            u29FPT5cHeM8bfVo6zixy7qC2lXzhK5gH/TLWXelpEwU+sw81oUbzZlB7Z2lvpj8
+            t4zXg4zgHNPqAFJM6L9b70dLgukhcUO6nnIiPPAprmtBDvXbtBwDCzOPaMcBeEwi
+            zERa4WyXYjn5Q+a8LTTLQ/OFmLHFA2dCG78s6cYQOfF92L641QdOhqXPtq+QwqAm
+            WkQ53Pes6rHmjT0kC8hEI5fCKEA3QXYt6YtgX+KIHgOYWI0g22wh95ohk+DuRL/O
+            3zzJ9tCjrMPO2lxmg0GdpuqjfR6K8CEk4Yq2dUwYC7dffgCrWv9zik/pXeoSvTv3
+            XprMN2WWKBX9lVC2qKFhNX4driBFRO0i5+bGdM1e8NilUDqHiikwhaVx2znb/E/b
+            LCCwlhC0oAAxnVZ1J18k46STe7hlg/RqM/18uxmhP9an2FkDtuyZBugbpWpgk7lE
+            tpOd92iCGYDc6k8Jsn+p0UiZjioJv/Gm04T3t90dkVu7D+mwFIsEAaJjwepEZ7ki
+            IBayWrJml+DT4ghyadkms8UaOa+YOYEZiY5GzJhEodAt01OanSkzR/FYjM4SuGXw
+            Rrq2p8hTuUBBm1p9ipv8DLqPmlXZ2Cn7ByTX7TMsG+77R4zkka5XD5tULpAf5xKo
+            qx4N/QIDAQABo2YwZDAdBgNVHQ4EFgQUbA2I9pZUJ7Z6WxXfTRecoCsqfnUwHwYD
+            VR0jBBgwFoAUY5U4Jb8hC6Ssinh2LzCB3tly8bcwEgYDVR0TAQH/BAgwBgEB/wIB
+            ADAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAHMtenslnEuvnT4g
+            JWR70FZv3wUOOqAsyxJdWj4o8yM7/V3wGKMxkRv7Oqetp92XYauffSPxE3INnGMq
+            DdRMTf2MGVnv/W5PJouZwMhBX4W6rjvl4QCSl+Q+wSt+OibNu2AxdCeQKa67cwvf
+            QfD4ufeWfvUPzazwzuJqE5WCjNnM2KsWbmzclquAbUjKH0017UGRYe8THrCZ5Mdn
+            L9X+ZSe5wWHWIm7JLn5nexeW668hgcdINrKBRg7ygKWrO/aMFnl3cQXmbNtXBt+y
+            E5tof618/HWJBjC3e+eyIMqjgjEZmxYfxwBTk0XVEZuA3PyAGigA17Q0ev5Zx4ii
+            2fGIYN5y3L6OMrfkcmdtihoQisqd+zKlgxWH4Z2KtV0RFVTreooNaSpFZu6EeCPH
+            0fg++TV/uGOEfNc4seEfFiaM4uq8mp5E1PYOXX4DLkzignqql9h8u3/3ZC7m4NoY
+            qpoOurQyY/dCUIJw3Kb+Dlck1OZsGQNvkpflHvCxCvTq48bEgjO+xkoYBODhY0wT
+            grl1kFBXMNNAiFiHlHaM6h+MKv/9cRi63KXmhiEjUWUVcdT9ZRRPJ6qd5QAJHJ+h
+            NU7s17ar5/4SgJx9BZSEYzQQCzt4REwBxfrF/GdGNia1wZcqMNylmkD8fCWBZiW2
+            sarsDzVzwvduL1ODIycXxe/pZUxi
+            -----END CERTIFICATE-----
+            -----BEGIN CERTIFICATE-----
+            MIIGgjCCBGqgAwIBAgIJAKBdlRUnXXIJMA0GCSqGSIb3DQEBCwUAMIHNMQswCQYD
+            VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
+            JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
+            RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
+            cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
+            bm93LmNvbTAeFw0xNzA4MDkxMTIyMTlaFw0yNzA4MDcxMTIyMTlaMIHNMQswCQYD
+            VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
+            JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
+            RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
+            cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
+            bm93LmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALDo08zRbssi
+            vrgIyCiE3x5ttHDcEsOs3EaZaE3hHpXK5an5iXT8/tl35BDAWl1J6CJkm4ip0Ch5
+            jOqrk5peQJKuN731GlafzoabwHcqyD6CvJZANre64s0J2CTZpob2gWM06C75uwzK
+            5W4JfivSzBpHu8A+FJARmZpnQoFDRIPWQFk9q22CPIWtlUdrkwVdnHlV++hRKKBU
+            qwAyXj6UUnrvwWNER0C0wksoJf+5oP/HLyqzUcd6yPmOiAe8QhR8jLdt/K8e14GI
+            7XhAytKxI2qHqzUmi2T57lIzz83fG4Cmo59mIF4jLvHfjC48zz9dCoObCK/QcczX
+            lipxmTm9HocDWCCo0L035arvWxRkP8ec75CE20Q8RqUY9jQo4a64RydbAabCw8s0
+            b0mSoHbRvpZCx96KhCG7EkjCorWrvh9dxZAenIZDAbn3sX9QGc6A+B5MYbv70UKo
+            8RD2IODsvuCSnn1rEQpGb0d6hNSReDN2cYLnSeuoMUlxT/SRCNBizGOWxJuFL1Cr
+            5YnNyUv3tCEXKxEM9OoRHutydmeg8fTbTu8hAlGiYhgqehmkApS25qCl4sVz3FUj
+            /y2yfQbecliu/YdPVziRGsLOTGhQldBSIaVdMGA/muzxVtOJdLBuK/qK/gvW7N2s
+            vZQTHZz+B10Dlxs9S2Nhf7FX7pMLM9hXAgMBAAGjYzBhMB0GA1UdDgQWBBRjlTgl
+            vyELpKyKeHYvMIHe2XLxtzAfBgNVHSMEGDAWgBRjlTglvyELpKyKeHYvMIHe2XLx
+            tzAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsF
+            AAOCAgEAcB4z4ALRX+s1Fb1j2sWLo65jIyxm0OB2RTlhstd4+zd+zFjLg7XE0O5j
+            Ilm3basVlLM2mTmi5CC4mvOBibSb6NlJr34GmKbfwYVLj3tpnlnA/HGGzHY3uoX6
+            zBUSIYRH10k2bmpM438fXtz9P+kHAkmsVj2Yk8uLg+tZDZEdM8qiWbaIZa+awHwL
+            DBhd1dQ7ZyejVJLKGyYwd7dMYLq04F4AqawPp2ksmcUtktU2Q+uGmJBkqgBzUTC+
+            64yPKBbPa2WFFDVtqt0r6qD2N7FD6v0b0PiBeruvhpSva1yvE0vMNfa9kc8ExrKz
+            7GMMGsv3TIOqK0tYXJayoM+8VAELwBcFvkCkobs4TtkF3VoPiO91hlm7K+7woNQH
+            OVhxqDqH3ECA7vNLeA09xT7EApXzPGwk163O4qoZdT7VUI2Fu9G0+IzzS42TVXOm
+            MUp1sEidUUElwuuqDvKxsBP6do9xT8dHg2n9Y04ME2FyQ1omuLzRrcyjU6Qo6PLr
+            H/di6KT3iiZ/leFkDMf5/Pesy7bExPZN2sHR3SpR5RwQh50T4KZx7FOqvCJpi6Pp
+            H1cz0921qGtG0iheOzWfonmvYKnhxcTTpg+fuiVdPWwdutjVl+HPc2yjw1Gdqw4h
+            n4oFjG4KQO6zvZzGDFay9HazZyUKpgamy24u8XY7/BSWc1c95Gg=
+            -----END CERTIFICATE-----
+          cert: |-
+            -----BEGIN CERTIFICATE-----
+            MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
+            MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+            eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+            ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+            hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
+            MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
+            Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
+            RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
+            MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
+            AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
+            l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
+            uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
+            RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
+            dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
+            RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
+            BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
+            blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
+            6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
+            Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
+            EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
+            IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
+            ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
+            bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
+            BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
+            bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
+            dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
+            zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
+            Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
+            8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
+            IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
+            eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
+            cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
+            wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
+            dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
+            XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
+            fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
+            -----END CERTIFICATE-----
+          key: |-
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
+            p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
+            biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
+            kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
+            JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
+            xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
+            UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
+            FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
+            AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
+            ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
+            pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
+            lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
+            fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
+            Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
+            SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
+            qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
+            Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
+            6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
+            keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
+            ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
+            HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
+            pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
+            vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
+            P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
+            zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
+            -----END RSA PRIVATE KEY-----
+          cert_key: |-
+            -----BEGIN CERTIFICATE-----
+            MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
+            MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+            eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+            ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+            hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
+            MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
+            Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
+            RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
+            MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
+            AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
+            l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
+            uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
+            RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
+            dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
+            RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
+            BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
+            blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
+            6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
+            Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
+            EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
+            IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
+            ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
+            bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
+            BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
+            bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
+            dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
+            zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
+            Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
+            8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
+            IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
+            eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
+            cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
+            wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
+            dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
+            XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
+            fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
+            -----END CERTIFICATE-----
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
+            p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
+            biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
+            kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
+            JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
+            xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
+            UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
+            FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
+            AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
+            ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
+            pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
+            lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
+            fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
+            Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
+            SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
+            qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
+            Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
+            6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
+            keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
+            ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
+            HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
+            pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
+            vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
+            P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
+            zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
+            -----END RSA PRIVATE KEY-----
 
 internal-data:
   data:
     aws:
       bucket: local
   mongo:
+    credentials:
+      # The credentials to be used to communicate with Mongo and the database to be created
+      root_username: 'mongo'
+      root_password: 'mongo'
+      database: 'gmdata'
+      admin_password: 'mongopassword'
     ssl:
       certificates:
-      - name: mongo-ssl-certs
-        ca: |-
-          -----BEGIN CERTIFICATE-----
-          MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT
-          MREwDwYDVQQIDAhWaXJnaW5pYTETMBEGA1UEBwwKQWxleGFuZHJpYTEkMCIGA1UE
-          CgwbRGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVl
-          cmluZzEuMCwGA1UEAwwlRGVjaXBoZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChS
-          b290KTEqMCgGCSqGSIb3DQEJARYbZW5naW5lZXJpbmdAZGVjaXBoZXJub3cuY29t
-          MB4XDTE3MDgwOTExMjMwOFoXDTI3MDgwNzExMjMwOFowgcAxCzAJBgNVBAYTAlVT
-          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
-          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
-          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
-          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wggIiMA0GCSqGSIb3
-          DQEBAQUAA4ICDwAwggIKAoICAQDPkxaiUD3uqR2AA5jwAb9gCjD+BrOrYBoelnR6
-          u29FPT5cHeM8bfVo6zixy7qC2lXzhK5gH/TLWXelpEwU+sw81oUbzZlB7Z2lvpj8
-          t4zXg4zgHNPqAFJM6L9b70dLgukhcUO6nnIiPPAprmtBDvXbtBwDCzOPaMcBeEwi
-          zERa4WyXYjn5Q+a8LTTLQ/OFmLHFA2dCG78s6cYQOfF92L641QdOhqXPtq+QwqAm
-          WkQ53Pes6rHmjT0kC8hEI5fCKEA3QXYt6YtgX+KIHgOYWI0g22wh95ohk+DuRL/O
-          3zzJ9tCjrMPO2lxmg0GdpuqjfR6K8CEk4Yq2dUwYC7dffgCrWv9zik/pXeoSvTv3
-          XprMN2WWKBX9lVC2qKFhNX4driBFRO0i5+bGdM1e8NilUDqHiikwhaVx2znb/E/b
-          LCCwlhC0oAAxnVZ1J18k46STe7hlg/RqM/18uxmhP9an2FkDtuyZBugbpWpgk7lE
-          tpOd92iCGYDc6k8Jsn+p0UiZjioJv/Gm04T3t90dkVu7D+mwFIsEAaJjwepEZ7ki
-          IBayWrJml+DT4ghyadkms8UaOa+YOYEZiY5GzJhEodAt01OanSkzR/FYjM4SuGXw
-          Rrq2p8hTuUBBm1p9ipv8DLqPmlXZ2Cn7ByTX7TMsG+77R4zkka5XD5tULpAf5xKo
-          qx4N/QIDAQABo2YwZDAdBgNVHQ4EFgQUbA2I9pZUJ7Z6WxXfTRecoCsqfnUwHwYD
-          VR0jBBgwFoAUY5U4Jb8hC6Ssinh2LzCB3tly8bcwEgYDVR0TAQH/BAgwBgEB/wIB
-          ADAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAHMtenslnEuvnT4g
-          JWR70FZv3wUOOqAsyxJdWj4o8yM7/V3wGKMxkRv7Oqetp92XYauffSPxE3INnGMq
-          DdRMTf2MGVnv/W5PJouZwMhBX4W6rjvl4QCSl+Q+wSt+OibNu2AxdCeQKa67cwvf
-          QfD4ufeWfvUPzazwzuJqE5WCjNnM2KsWbmzclquAbUjKH0017UGRYe8THrCZ5Mdn
-          L9X+ZSe5wWHWIm7JLn5nexeW668hgcdINrKBRg7ygKWrO/aMFnl3cQXmbNtXBt+y
-          E5tof618/HWJBjC3e+eyIMqjgjEZmxYfxwBTk0XVEZuA3PyAGigA17Q0ev5Zx4ii
-          2fGIYN5y3L6OMrfkcmdtihoQisqd+zKlgxWH4Z2KtV0RFVTreooNaSpFZu6EeCPH
-          0fg++TV/uGOEfNc4seEfFiaM4uq8mp5E1PYOXX4DLkzignqql9h8u3/3ZC7m4NoY
-          qpoOurQyY/dCUIJw3Kb+Dlck1OZsGQNvkpflHvCxCvTq48bEgjO+xkoYBODhY0wT
-          grl1kFBXMNNAiFiHlHaM6h+MKv/9cRi63KXmhiEjUWUVcdT9ZRRPJ6qd5QAJHJ+h
-          NU7s17ar5/4SgJx9BZSEYzQQCzt4REwBxfrF/GdGNia1wZcqMNylmkD8fCWBZiW2
-          sarsDzVzwvduL1ODIycXxe/pZUxi
-          -----END CERTIFICATE-----
-          -----BEGIN CERTIFICATE-----
-          MIIGgjCCBGqgAwIBAgIJAKBdlRUnXXIJMA0GCSqGSIb3DQEBCwUAMIHNMQswCQYD
-          VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
-          JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
-          RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
-          cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
-          bm93LmNvbTAeFw0xNzA4MDkxMTIyMTlaFw0yNzA4MDcxMTIyMTlaMIHNMQswCQYD
-          VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
-          JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
-          RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
-          cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
-          bm93LmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALDo08zRbssi
-          vrgIyCiE3x5ttHDcEsOs3EaZaE3hHpXK5an5iXT8/tl35BDAWl1J6CJkm4ip0Ch5
-          jOqrk5peQJKuN731GlafzoabwHcqyD6CvJZANre64s0J2CTZpob2gWM06C75uwzK
-          5W4JfivSzBpHu8A+FJARmZpnQoFDRIPWQFk9q22CPIWtlUdrkwVdnHlV++hRKKBU
-          qwAyXj6UUnrvwWNER0C0wksoJf+5oP/HLyqzUcd6yPmOiAe8QhR8jLdt/K8e14GI
-          7XhAytKxI2qHqzUmi2T57lIzz83fG4Cmo59mIF4jLvHfjC48zz9dCoObCK/QcczX
-          lipxmTm9HocDWCCo0L035arvWxRkP8ec75CE20Q8RqUY9jQo4a64RydbAabCw8s0
-          b0mSoHbRvpZCx96KhCG7EkjCorWrvh9dxZAenIZDAbn3sX9QGc6A+B5MYbv70UKo
-          8RD2IODsvuCSnn1rEQpGb0d6hNSReDN2cYLnSeuoMUlxT/SRCNBizGOWxJuFL1Cr
-          5YnNyUv3tCEXKxEM9OoRHutydmeg8fTbTu8hAlGiYhgqehmkApS25qCl4sVz3FUj
-          /y2yfQbecliu/YdPVziRGsLOTGhQldBSIaVdMGA/muzxVtOJdLBuK/qK/gvW7N2s
-          vZQTHZz+B10Dlxs9S2Nhf7FX7pMLM9hXAgMBAAGjYzBhMB0GA1UdDgQWBBRjlTgl
-          vyELpKyKeHYvMIHe2XLxtzAfBgNVHSMEGDAWgBRjlTglvyELpKyKeHYvMIHe2XLx
-          tzAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsF
-          AAOCAgEAcB4z4ALRX+s1Fb1j2sWLo65jIyxm0OB2RTlhstd4+zd+zFjLg7XE0O5j
-          Ilm3basVlLM2mTmi5CC4mvOBibSb6NlJr34GmKbfwYVLj3tpnlnA/HGGzHY3uoX6
-          zBUSIYRH10k2bmpM438fXtz9P+kHAkmsVj2Yk8uLg+tZDZEdM8qiWbaIZa+awHwL
-          DBhd1dQ7ZyejVJLKGyYwd7dMYLq04F4AqawPp2ksmcUtktU2Q+uGmJBkqgBzUTC+
-          64yPKBbPa2WFFDVtqt0r6qD2N7FD6v0b0PiBeruvhpSva1yvE0vMNfa9kc8ExrKz
-          7GMMGsv3TIOqK0tYXJayoM+8VAELwBcFvkCkobs4TtkF3VoPiO91hlm7K+7woNQH
-          OVhxqDqH3ECA7vNLeA09xT7EApXzPGwk163O4qoZdT7VUI2Fu9G0+IzzS42TVXOm
-          MUp1sEidUUElwuuqDvKxsBP6do9xT8dHg2n9Y04ME2FyQ1omuLzRrcyjU6Qo6PLr
-          H/di6KT3iiZ/leFkDMf5/Pesy7bExPZN2sHR3SpR5RwQh50T4KZx7FOqvCJpi6Pp
-          H1cz0921qGtG0iheOzWfonmvYKnhxcTTpg+fuiVdPWwdutjVl+HPc2yjw1Gdqw4h
-          n4oFjG4KQO6zvZzGDFay9HazZyUKpgamy24u8XY7/BSWc1c95Gg=
-          -----END CERTIFICATE-----
-        cert: |-
-          -----BEGIN CERTIFICATE-----
-          MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
-          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
-          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
-          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
-          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
-          MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
-          Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
-          RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
-          MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
-          AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
-          l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
-          uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
-          RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
-          dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
-          RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
-          BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
-          blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
-          6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
-          Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
-          EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
-          IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
-          ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
-          bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
-          BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
-          bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
-          dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
-          zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
-          Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
-          8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
-          IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
-          eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
-          cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
-          wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
-          dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
-          XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
-          fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
-          -----END CERTIFICATE-----
-        key: |-
-          -----BEGIN RSA PRIVATE KEY-----
-          MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
-          p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
-          biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
-          kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
-          JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
-          xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
-          UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
-          FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
-          AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
-          ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
-          pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
-          lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
-          fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
-          Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
-          SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
-          qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
-          Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
-          6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
-          keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
-          ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
-          HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
-          pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
-          vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
-          P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
-          zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
-          -----END RSA PRIVATE KEY-----
-        cert_key: |-
-          -----BEGIN CERTIFICATE-----
-          MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
-          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
-          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
-          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
-          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
-          MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
-          Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
-          RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
-          MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
-          AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
-          l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
-          uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
-          RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
-          dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
-          RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
-          BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
-          blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
-          6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
-          Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
-          EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
-          IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
-          ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
-          bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
-          BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
-          bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
-          dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
-          zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
-          Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
-          8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
-          IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
-          eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
-          cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
-          wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
-          dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
-          XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
-          fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
-          -----END CERTIFICATE-----
-          -----BEGIN RSA PRIVATE KEY-----
-          MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
-          p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
-          biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
-          kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
-          JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
-          xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
-          UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
-          FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
-          AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
-          ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
-          pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
-          lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
-          fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
-          Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
-          SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
-          qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
-          Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
-          6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
-          keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
-          ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
-          HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
-          pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
-          vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
-          P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
-          zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
-          -----END RSA PRIVATE KEY-----
+        - name: mongo-ssl-certs
+          ca: |-
+            -----BEGIN CERTIFICATE-----
+            MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT
+            MREwDwYDVQQIDAhWaXJnaW5pYTETMBEGA1UEBwwKQWxleGFuZHJpYTEkMCIGA1UE
+            CgwbRGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVl
+            cmluZzEuMCwGA1UEAwwlRGVjaXBoZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChS
+            b290KTEqMCgGCSqGSIb3DQEJARYbZW5naW5lZXJpbmdAZGVjaXBoZXJub3cuY29t
+            MB4XDTE3MDgwOTExMjMwOFoXDTI3MDgwNzExMjMwOFowgcAxCzAJBgNVBAYTAlVT
+            MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+            eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+            ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+            hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wggIiMA0GCSqGSIb3
+            DQEBAQUAA4ICDwAwggIKAoICAQDPkxaiUD3uqR2AA5jwAb9gCjD+BrOrYBoelnR6
+            u29FPT5cHeM8bfVo6zixy7qC2lXzhK5gH/TLWXelpEwU+sw81oUbzZlB7Z2lvpj8
+            t4zXg4zgHNPqAFJM6L9b70dLgukhcUO6nnIiPPAprmtBDvXbtBwDCzOPaMcBeEwi
+            zERa4WyXYjn5Q+a8LTTLQ/OFmLHFA2dCG78s6cYQOfF92L641QdOhqXPtq+QwqAm
+            WkQ53Pes6rHmjT0kC8hEI5fCKEA3QXYt6YtgX+KIHgOYWI0g22wh95ohk+DuRL/O
+            3zzJ9tCjrMPO2lxmg0GdpuqjfR6K8CEk4Yq2dUwYC7dffgCrWv9zik/pXeoSvTv3
+            XprMN2WWKBX9lVC2qKFhNX4driBFRO0i5+bGdM1e8NilUDqHiikwhaVx2znb/E/b
+            LCCwlhC0oAAxnVZ1J18k46STe7hlg/RqM/18uxmhP9an2FkDtuyZBugbpWpgk7lE
+            tpOd92iCGYDc6k8Jsn+p0UiZjioJv/Gm04T3t90dkVu7D+mwFIsEAaJjwepEZ7ki
+            IBayWrJml+DT4ghyadkms8UaOa+YOYEZiY5GzJhEodAt01OanSkzR/FYjM4SuGXw
+            Rrq2p8hTuUBBm1p9ipv8DLqPmlXZ2Cn7ByTX7TMsG+77R4zkka5XD5tULpAf5xKo
+            qx4N/QIDAQABo2YwZDAdBgNVHQ4EFgQUbA2I9pZUJ7Z6WxXfTRecoCsqfnUwHwYD
+            VR0jBBgwFoAUY5U4Jb8hC6Ssinh2LzCB3tly8bcwEgYDVR0TAQH/BAgwBgEB/wIB
+            ADAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAHMtenslnEuvnT4g
+            JWR70FZv3wUOOqAsyxJdWj4o8yM7/V3wGKMxkRv7Oqetp92XYauffSPxE3INnGMq
+            DdRMTf2MGVnv/W5PJouZwMhBX4W6rjvl4QCSl+Q+wSt+OibNu2AxdCeQKa67cwvf
+            QfD4ufeWfvUPzazwzuJqE5WCjNnM2KsWbmzclquAbUjKH0017UGRYe8THrCZ5Mdn
+            L9X+ZSe5wWHWIm7JLn5nexeW668hgcdINrKBRg7ygKWrO/aMFnl3cQXmbNtXBt+y
+            E5tof618/HWJBjC3e+eyIMqjgjEZmxYfxwBTk0XVEZuA3PyAGigA17Q0ev5Zx4ii
+            2fGIYN5y3L6OMrfkcmdtihoQisqd+zKlgxWH4Z2KtV0RFVTreooNaSpFZu6EeCPH
+            0fg++TV/uGOEfNc4seEfFiaM4uq8mp5E1PYOXX4DLkzignqql9h8u3/3ZC7m4NoY
+            qpoOurQyY/dCUIJw3Kb+Dlck1OZsGQNvkpflHvCxCvTq48bEgjO+xkoYBODhY0wT
+            grl1kFBXMNNAiFiHlHaM6h+MKv/9cRi63KXmhiEjUWUVcdT9ZRRPJ6qd5QAJHJ+h
+            NU7s17ar5/4SgJx9BZSEYzQQCzt4REwBxfrF/GdGNia1wZcqMNylmkD8fCWBZiW2
+            sarsDzVzwvduL1ODIycXxe/pZUxi
+            -----END CERTIFICATE-----
+            -----BEGIN CERTIFICATE-----
+            MIIGgjCCBGqgAwIBAgIJAKBdlRUnXXIJMA0GCSqGSIb3DQEBCwUAMIHNMQswCQYD
+            VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
+            JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
+            RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
+            cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
+            bm93LmNvbTAeFw0xNzA4MDkxMTIyMTlaFw0yNzA4MDcxMTIyMTlaMIHNMQswCQYD
+            VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
+            JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
+            RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
+            cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
+            bm93LmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALDo08zRbssi
+            vrgIyCiE3x5ttHDcEsOs3EaZaE3hHpXK5an5iXT8/tl35BDAWl1J6CJkm4ip0Ch5
+            jOqrk5peQJKuN731GlafzoabwHcqyD6CvJZANre64s0J2CTZpob2gWM06C75uwzK
+            5W4JfivSzBpHu8A+FJARmZpnQoFDRIPWQFk9q22CPIWtlUdrkwVdnHlV++hRKKBU
+            qwAyXj6UUnrvwWNER0C0wksoJf+5oP/HLyqzUcd6yPmOiAe8QhR8jLdt/K8e14GI
+            7XhAytKxI2qHqzUmi2T57lIzz83fG4Cmo59mIF4jLvHfjC48zz9dCoObCK/QcczX
+            lipxmTm9HocDWCCo0L035arvWxRkP8ec75CE20Q8RqUY9jQo4a64RydbAabCw8s0
+            b0mSoHbRvpZCx96KhCG7EkjCorWrvh9dxZAenIZDAbn3sX9QGc6A+B5MYbv70UKo
+            8RD2IODsvuCSnn1rEQpGb0d6hNSReDN2cYLnSeuoMUlxT/SRCNBizGOWxJuFL1Cr
+            5YnNyUv3tCEXKxEM9OoRHutydmeg8fTbTu8hAlGiYhgqehmkApS25qCl4sVz3FUj
+            /y2yfQbecliu/YdPVziRGsLOTGhQldBSIaVdMGA/muzxVtOJdLBuK/qK/gvW7N2s
+            vZQTHZz+B10Dlxs9S2Nhf7FX7pMLM9hXAgMBAAGjYzBhMB0GA1UdDgQWBBRjlTgl
+            vyELpKyKeHYvMIHe2XLxtzAfBgNVHSMEGDAWgBRjlTglvyELpKyKeHYvMIHe2XLx
+            tzAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsF
+            AAOCAgEAcB4z4ALRX+s1Fb1j2sWLo65jIyxm0OB2RTlhstd4+zd+zFjLg7XE0O5j
+            Ilm3basVlLM2mTmi5CC4mvOBibSb6NlJr34GmKbfwYVLj3tpnlnA/HGGzHY3uoX6
+            zBUSIYRH10k2bmpM438fXtz9P+kHAkmsVj2Yk8uLg+tZDZEdM8qiWbaIZa+awHwL
+            DBhd1dQ7ZyejVJLKGyYwd7dMYLq04F4AqawPp2ksmcUtktU2Q+uGmJBkqgBzUTC+
+            64yPKBbPa2WFFDVtqt0r6qD2N7FD6v0b0PiBeruvhpSva1yvE0vMNfa9kc8ExrKz
+            7GMMGsv3TIOqK0tYXJayoM+8VAELwBcFvkCkobs4TtkF3VoPiO91hlm7K+7woNQH
+            OVhxqDqH3ECA7vNLeA09xT7EApXzPGwk163O4qoZdT7VUI2Fu9G0+IzzS42TVXOm
+            MUp1sEidUUElwuuqDvKxsBP6do9xT8dHg2n9Y04ME2FyQ1omuLzRrcyjU6Qo6PLr
+            H/di6KT3iiZ/leFkDMf5/Pesy7bExPZN2sHR3SpR5RwQh50T4KZx7FOqvCJpi6Pp
+            H1cz0921qGtG0iheOzWfonmvYKnhxcTTpg+fuiVdPWwdutjVl+HPc2yjw1Gdqw4h
+            n4oFjG4KQO6zvZzGDFay9HazZyUKpgamy24u8XY7/BSWc1c95Gg=
+            -----END CERTIFICATE-----
+          cert: |-
+            -----BEGIN CERTIFICATE-----
+            MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
+            MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+            eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+            ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+            hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
+            MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
+            Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
+            RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
+            MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
+            AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
+            l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
+            uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
+            RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
+            dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
+            RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
+            BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
+            blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
+            6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
+            Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
+            EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
+            IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
+            ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
+            bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
+            BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
+            bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
+            dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
+            zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
+            Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
+            8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
+            IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
+            eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
+            cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
+            wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
+            dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
+            XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
+            fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
+            -----END CERTIFICATE-----
+          key: |-
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
+            p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
+            biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
+            kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
+            JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
+            xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
+            UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
+            FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
+            AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
+            ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
+            pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
+            lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
+            fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
+            Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
+            SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
+            qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
+            Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
+            6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
+            keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
+            ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
+            HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
+            pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
+            vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
+            P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
+            zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
+            -----END RSA PRIVATE KEY-----
+          cert_key: |-
+            -----BEGIN CERTIFICATE-----
+            MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
+            MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+            eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+            ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+            hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
+            MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
+            Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
+            RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
+            MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
+            AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
+            l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
+            uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
+            RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
+            dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
+            RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
+            BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
+            blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
+            6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
+            Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
+            EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
+            IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
+            ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
+            bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
+            BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
+            bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
+            dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
+            zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
+            Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
+            8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
+            IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
+            eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
+            cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
+            wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
+            dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
+            XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
+            fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
+            -----END CERTIFICATE-----
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
+            p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
+            biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
+            kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
+            JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
+            xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
+            UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
+            FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
+            AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
+            ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
+            pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
+            lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
+            fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
+            Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
+            SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
+            qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
+            Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
+            6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
+            keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
+            ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
+            HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
+            pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
+            vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
+            P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
+            zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
+            -----END RSA PRIVATE KEY-----
 
 slo:
   postgres:
+    credentials:
+      # The credentials to be used to communicate with Postgres and the database to be created
+      username: greymatter
+      password: greymatter
+      database: greymatter
     ssl:
       certificates:
         ca: |-
@@ -590,7 +606,12 @@ slo:
           -----END RSA PRIVATE KEY-----
 
 internal-jwt:
+  redis:
+    # The password that will be used to authenticate with Redis
+    password: internalRedis
   jwt:
+    # The password that will be used to authenticate with Redis
+    redis_pass: internalRedis
     secrets:
       - name: internal-jwt-security-secret
         jwt.key: |-
@@ -896,7 +917,12 @@ internal-jwt:
           -----END CERTIFICATE-----
 
 jwt:
+  redis:
+    # The password that will be used to authenticate with Redis
+    password: redis
   jwt:
+    # The password that will be used to authenticate with Redis
+    redis_pass: redis
     secrets:
       - name: jwt-certs
         jwt.cert.pem: |-


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

We leverage the  `greymatter-secrets.yaml` custom file to store Grey Matter certificates and other secrets, but it did not include credentials for Mongo, Postgres and Redis.  This PR just moves them into this file so they're more visible for customers.

2. What **changes to custom.yaml** are required?

n/a

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

n/a
