### PR TITLE
WIP: Updating dashboard route_match to exact rather than prefix

### DIFF
--- a/gm-control-api/json/special/route-dashboard-slash.json
+++ b/gm-control-api/json/special/route-dashboard-slash.json
@@ -2,7 +2,10 @@
   "route_key": "edge-dashboard-route-no-slash",
   "domain_key": "edge",
   "zone_key": "{{ .Values.gmControlApi.zone }}",
-  "path": "/",
+  "route_match": {
+    "path": "/",
+    "match_type": "exact"
+  },
   "prefix_rewrite": null,
   "redirects": null,
   "shared_rules_key": "edge-dashboard-shared-rules",


### PR DESCRIPTION
This PR is created for a reference purpose so that if gm-control-api version gets upgraded to 1.1.0 and the issue (https://github.com/DecipherNow/greymatter/issues/168) needs to be resolved while I am away, it can be tested and merged. 

1. See above

2. N/A

3. No additional setups. 

4. The way to test this would be to:
- Deploy the greymatter core services using helm to EC2 instance running minikube (or any environment available to you)
- Access edge pod's terminal, run`wget localhost:8001/config_dump` and take a look at config_dump making sure that the very last entry looks something like:
```
         {
          "match": {
           "path": "/",    <-- the important part. Not prefix
           "case_sensitive": false
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "dashboard",
              "weight": 1,
              "metadata_match": {},
              "request_headers_to_add": [
               {
                "header": {
                 "key": "x-gm-constraint"
                },
                "append": false
               }
              ]
             }
            ],
            "total_weight": 1
           },
           "timeout": "60s",
           "retry_policy": {
            "retry_on": "connect-failure,refused-stream,gateway-error",
            "num_retries": 2,
            "per_try_timeout": "60s"
           }
          },
```
- Check 2 things. First, try going to https://<the public IP address>:<port if you need>/blah. This should not display the dashboard with URL that looks like https://<the public IP address>:<port if you need>/blah#/ . The expected results is 404 response from edge node.
- Second, try going to https://<the public IP address>:<port if you need>/foo/bar (notice the subfolder). This should not display a blank page. The expected results is 404 response from edge node.


