### PR TITLE
remove cluster.local

### DIFF
--- a/catalog/Chart.yaml
+++ b/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.2
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 2.1.0
+version: 2.1.1
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/catalog/templates/_helpers.tpl
+++ b/catalog/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Define the exhibitor host.
 {{- define "greymatter.exhibitor.address" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.global.exhibitor.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc.cluster.local:2181" | append $zk.servers | set $zk "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc:2181" | append $zk.servers | set $zk "servers" -}}
 {{- end -}}
 {{- join "," $zk.servers | quote -}}
 {{- end -}}

--- a/catalog/templates/bootstrap-zone-configmap.yaml
+++ b/catalog/templates/bootstrap-zone-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   zone.json: |-
     {
-      "serverAddress": "{{ .Values.global.control.name}}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.control.port }}",
+      "serverAddress": "{{ .Values.global.control.name}}.{{ .Release.Namespace }}.svc:{{ .Values.global.control.port }}",
       "zoneName": "{{ .Values.global.zone }}",
       "requestCluster": "edge"
     }

--- a/control/Chart.yaml
+++ b/control/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.0.2
 description: Deploys the Grey Matter 2.0 control server
 name: control
-version: 2.1.0
+version: 2.1.1

--- a/dashboard/Chart.yaml
+++ b/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 3.2.0
 description: A Helm chart to deploy Grey Matter Dashboard
 name: dashboard
-version: 2.1.0
+version: 2.1.1
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/dashboard/templates/_helpers.tpl
+++ b/dashboard/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Define the exhibitor host.
 {{- define "greymatter.exhibitor.address" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.global.exhibitor.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc.cluster.local:2181" | append $zk.servers | set $zk "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc:2181" | append $zk.servers | set $zk "servers" -}}
 {{- end -}}
 {{- join "," $zk.servers | quote -}}
 {{- end -}}

--- a/dashboard/values.yaml
+++ b/dashboard/values.yaml
@@ -130,7 +130,7 @@ sidecar_prometheus:
       value: 'prometheus'
     xds_host:
       type: 'value'
-      value: 'control.{{ .Release.Namespace }}.svc.cluster.local'
+      value: 'control.{{ .Release.Namespace }}.svc'
     xds_port:
       type: 'value'
       value: '{{ .Values.global.control.port }}'

--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 2.1.1
+version: 2.1.2
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/data/templates/_helpers.tpl
+++ b/data/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Define the exhibitor host.
 {{- define "greymatter.exhibitor.address" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.global.exhibitor.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc.cluster.local:2181" | append $zk.servers | set $zk "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc:2181" | append $zk.servers | set $zk "servers" -}}
 {{- end -}}
 {{- join "," $zk.servers | quote -}}
 {{- end -}}
@@ -15,7 +15,7 @@ Define the mongo host.
 {{- define "greymatter.mongo.address" -}}
 {{- $mongo := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.mongo.replicas))) -}} 
-{{- $noop := printf "%s%s%d.%s.%s.%s"  $.Values.mongo.name "-" . $.Values.mongo.name $.Release.Namespace "svc.cluster.local:27017" | append $mongo.servers | set $mongo "servers" -}}
+{{- $noop := printf "%s%s%d.%s.%s.%s"  $.Values.mongo.name "-" . $.Values.mongo.name $.Release.Namespace "svc:27017" | append $mongo.servers | set $mongo "servers" -}}
 {{- end -}}
 {{- join "," $mongo.servers | quote -}}
 {{- end -}}

--- a/documentation/Chart.yaml
+++ b/documentation/Chart.yaml
@@ -2,7 +2,7 @@ apiCersion: v1
 appVersion: 3.0.0
 description: A Helm chart to deploy Grey Matter Documentation Site
 name: documentation
-version: 1.0.3
+version: 1.0.4
 icon: 
 maintainers:
     - name: Decipher Technology Studios Engineering

--- a/documentation/templates/_helpers.tpl
+++ b/documentation/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Define the exhibitor host.
 {{- define "greymatter.exhibitor.address" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.global.exhibitor.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc.cluster.local:2181" | append $zk.servers | set $zk "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc:2181" | append $zk.servers | set $zk "servers" -}}
 {{- end -}}
 {{- join "," $zk.servers | quote -}}
 {{- end -}}
@@ -15,7 +15,7 @@ Define the mongo host.
 {{- define "greymatter.mongo.address" -}}
 {{- $mongo := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.mongo.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "mongo-" . "mongo" $.Release.Namespace "svc.cluster.local:27017" | append $mongo.servers | set $mongo "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "mongo-" . "mongo" $.Release.Namespace "svc:27017" | append $mongo.servers | set $mongo "servers" -}}
 {{- end -}}
 {{- join "," $mongo.servers | quote -}}
 {{- end -}}

--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 2.1.0
+version: 2.1.1
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/edge/templates/_helpers.tpl
+++ b/edge/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Define the exhibitor host.
 {{- define "greymatter.exhibitor.address" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.global.exhibitor.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc.cluster.local:2181" | append $zk.servers | set $zk "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc:2181" | append $zk.servers | set $zk "servers" -}}
 {{- end -}}
 {{- join "," $zk.servers | quote -}}
 {{- end -}}

--- a/gm-control-api/Chart.yaml
+++ b/gm-control-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.0.2
 description: Deploys the Grey Matter 2.0 gm-control-api mesh-wide configuration API
 name: gm-control-api
-version: 2.1.0
+version: 2.1.1

--- a/greymatter.yaml
+++ b/greymatter.yaml
@@ -87,7 +87,7 @@ global:
         value: ''
       xds_host:
         type: 'value'
-        value: 'control.{{ .Release.Namespace }}.svc.cluster.local'
+        value: 'control.{{ .Release.Namespace }}.svc'
       xds_port:
         type: 'value'
         value: '{{ .Values.global.control.port }}'
@@ -278,7 +278,7 @@ data:
         key: root_password
       mongo_client_dn:
         type: value
-        value: CN=*.greymatter.svc.cluster.local, OU=Engineering, O=Decipher Technology Studios, L=Alexandria, ST=Virginia, C=US
+        value: CN=*.greymatter.svc, OU=Engineering, O=Decipher Technology Studios, L=Alexandria, ST=Virginia, C=US
 
 internal-data:
   sidecar:
@@ -364,7 +364,7 @@ internal-data:
         key: root_password
       mongo_client_dn:
         type: value
-        value: CN=*.greymatter.svc.cluster.local, OU=Engineering, O=Decipher Technology Studios, L=Alexandria, ST=Virginia, C=US
+        value: CN=*.greymatter.svc, OU=Engineering, O=Decipher Technology Studios, L=Alexandria, ST=Virginia, C=US
 
 catalog:
   catalog:
@@ -392,7 +392,7 @@ catalog:
         value: '9080'
       control_server_0_address:
         type: value
-        value: '{{ .Values.global.control.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.control.port }}'
+        value: '{{ .Values.global.control.name }}.{{ .Release.Namespace }}.svc:{{ .Values.global.control.port }}'
       control_server_0_zone_name:
         type: value
         value: '{{ .Values.global.zone }}'
@@ -538,7 +538,7 @@ slo:
         key: password
       - type: value
         name: POSTGRES_USER_CN
-        value: CN=*.greymatter.svc.cluster.local, OU=Engineering, O=Decipher Technology Studios, L=Alexandria, ST=Virginia, C=US
+        value: CN=*.greymatter.svc, OU=Engineering, O=Decipher Technology Studios, L=Alexandria, ST=Virginia, C=US
       - type: secret
         name: POSTGRESQL_DATABASE
         secret: postgres-credentials
@@ -586,7 +586,7 @@ jwt:
         key: jwt.key.pem
       - type: value
         name: JWT_AACHOST
-        value: aac.memecore.svc.cluster.local
+        value: aac.memecore.svc
       - type: value
         name: JWT_AACPORT
         value: 9080

--- a/greymatter/Chart.yaml
+++ b/greymatter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.1.0
 description: A Helm chart to deploy Grey Matter
 name: greymatter
-version: 2.1.0
+version: 2.1.1
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/greymatter/requirements-dev.yaml
+++ b/greymatter/requirements-dev.yaml
@@ -1,36 +1,47 @@
 dependencies:
   - name: catalog
     repository: 'file://../catalog'
-    version: '2.0.1'
+    version: '2.1.1'
 
   - name: data
     repository: 'file://../data'
-    version: '2.0.2'
+    version: '2.1.2'
+
+  - name: data
+    repository: 'file://../data'
+    version: '2.1.2'
+    alias: internal-data
 
   - name: dashboard
     repository: 'file://../dashboard'
-    version: '2.0.1'
-
-  - name: documentation
-    repository: 'file://../documentation'
-    version: '2.0.1'
+    version: '2.1.1'
 
   - name: edge
     repository: 'file://../edge'
-    version: '2.0.1'
-
-  - name: xds
-    repository: 'file://../xds'
-    version: '2.0.1'
-
-  - name: exhibitor
-    repository: 'file://../exhibitor'
-    version: '2.0.1'
+    version: '2.1.1'
 
   - name: jwt
     repository: 'file://../jwt'
-    version: '2.0.1'
+    version: '2.1.1'
+
+  - name: jwt
+    repository: 'file://../jwt'
+    version: '2.1.1'
+    alias: internal-jwt
 
   - name: slo
     repository: 'file://../slo'
-    version: '2.0.2'
+    version: '2.1.1'
+
+  - name: gm-control-api
+    repository: 'file://../gm-control-api'
+    version: '2.1.1'
+
+  - name: control
+    repository: 'file://../control'
+    version: '2.1.1'
+
+  - name: spire
+    repository: 'file://../spire'
+    version: '2.1.1'
+    condition: global.spire.enabled

--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -1,49 +1,49 @@
 dependencies:
   - name: catalog
-    version: '2.1.0'
+    version: '2.1.1'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: data
-    version: '2.1.1'
+    version: '2.1.2'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     alias: internal-data
 
     
   - name: data
-    version: '2.1.1'
+    version: '2.1.2'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
 
   - name: dashboard
-    version: '2.1.0'
+    version: '2.1.1'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: edge
-    version: '2.1.0'
+    version: '2.1.1'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: jwt
-    version: '2.1.0'
+    version: '2.1.1'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: jwt
-    version: '2.1.0'
+    version: '2.1.1'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     alias: internal-jwt
 
   - name: slo
-    version: '2.1.0'
+    version: '2.1.1'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: gm-control-api
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
-    version: '2.1.0'
+    version: '2.1.1'
 
   - name: control
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
-    version: '2.1.0'
+    version: '2.1.1'
 
   - name: spire
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
-    version: '2.1.0'
+    version: '2.1.1'
     condition: global.spire.enabled

--- a/jwt-gov/Chart.yaml
+++ b/jwt-gov/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
-version: 2.1.0
+version: 2.1.1
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/jwt-gov/templates/_helpers.tpl
+++ b/jwt-gov/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Define the exhibitor host.
 {{- define "greymatter.exhibitor.address" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.global.exhibitor.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc.cluster.local:2181" | append $zk.servers | set $zk "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc:2181" | append $zk.servers | set $zk "servers" -}}
 {{- end -}}
 {{- join "," $zk.servers | quote -}}
 {{- end -}}

--- a/jwt-gov/templates/jwt.yaml
+++ b/jwt-gov/templates/jwt.yaml
@@ -46,7 +46,7 @@ spec:
         {{- end }}
       {{- end  }}   
         - name: REDIS_HOST
-          value: {{ .Values.redis.name }}.{{ .Release.Namespace }}.svc.cluster.local
+          value: {{ .Values.redis.name }}.{{ .Release.Namespace }}.svc
         - name:  REDIS_PORT
           value: "6379"
         - name: REDIS_DB

--- a/jwt-gov/values.yaml
+++ b/jwt-gov/values.yaml
@@ -22,7 +22,6 @@ jwt:
       'if [[ ! -d ./certs ]]; then mkdir -p ./certs; fi && if [[ ! -d ./certs/aac ]]; then mkdir -p ./certs/aac; fi && if [[ ! -d ./etc ]]; then mkdir -p ./certs; fi && /app/gm-jwt-security-gov.linux',
 
     ]
-  #redis_host: redis.greymatter.svc.cluster.local
   redis_db: '0'
   redis_pass: redis
   egress_use_tls: 'true'

--- a/jwt/Chart.yaml
+++ b/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 2.1.0
+version: 2.1.1
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/jwt/templates/_helpers.tpl
+++ b/jwt/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Define the exhibitor host.
 {{- define "greymatter.exhibitor.address" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.global.exhibitor.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc.cluster.local:2181" | append $zk.servers | set $zk "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc:2181" | append $zk.servers | set $zk "servers" -}}
 {{- end -}}
 {{- join "," $zk.servers | quote -}}
 {{- end -}}

--- a/jwt/templates/jwt.yaml
+++ b/jwt/templates/jwt.yaml
@@ -46,7 +46,7 @@ spec:
         {{- end }}
       {{- end  }}   
         - name: REDIS_HOST
-          value: {{ .Values.redis.name }}.{{ .Release.Namespace }}.svc.cluster.local
+          value: {{ .Values.redis.name }}.{{ .Release.Namespace }}.svc
         - name:  REDIS_PORT
           value: "6379"
         - name: REDIS_DB

--- a/jwt/values.yaml
+++ b/jwt/values.yaml
@@ -18,7 +18,6 @@ global:
 jwt:
   version: '{{ .Values.global.jwt.version }}'
   image: 'docker.production.deciphernow.com/deciphernow/gm-jwt-security:{{ tpl $.Values.jwt.version $ }}'
-  #redis_host: redis.greymatter.svc.cluster.local
   command: ['/bin/sh']
   args:
     [

--- a/slo/Chart.yaml
+++ b/slo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
-version: 2.1.0
+version: 2.1.1
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/slo/templates/_helpers.tpl
+++ b/slo/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Define the exhibitor host.
 {{- define "greymatter.exhibitor.address" -}}
 {{- $zk := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.global.exhibitor.replicas))) -}} 
-{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc.cluster.local:2181" | append $zk.servers | set $zk "servers" -}}
+{{- $noop := printf "%s%d.%s.%s.%s"  "exhibitor-" . "exhibitor" $.Release.Namespace "svc:2181" | append $zk.servers | set $zk "servers" -}}
 {{- end -}}
 {{- join "," $zk.servers | quote -}}
 {{- end -}}

--- a/slo/templates/slo.yaml
+++ b/slo/templates/slo.yaml
@@ -57,7 +57,7 @@ spec:
               name: {{ .Values.postgres.credentials.secret_name }}
               key: database 
         - name: DATABASE_URI
-          value: postgres://$(POSTGRESQL_USERNAME):$(POSTGRESQL_PASSWORD)@postgres-slo.{{ .Release.Namespace }}.svc.cluster.local:5432/$(POSTGRESQL_DATABASE)
+          value: postgres://$(POSTGRESQL_USERNAME):$(POSTGRESQL_PASSWORD)@postgres-slo.{{ .Release.Namespace }}.svc:5432/$(POSTGRESQL_DATABASE)
         - name: SERVICE_PORT
           value: "1337"
         {{- if .Values.postgres.ssl.enabled }}

--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2"
 description: Deploys the SPIRE server which signs SVIDs and does Node attestation and resolution
 name: spire
-version: 2.1.0
+version: 2.1.1


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR removes `.cluster.local` from each host definition that calls a service (`x.namespace.svc.cluster.local`) .  This change allows the service mesh to be deployed into a cluster with a custom dns (service ex: `x.namespace.svc.testdecipher` would be the service inside a cluster called testdecipher).

To test:
- launch ec2 or local minikube
- install helm
- install gm2
- ensure the dashboard is visable
- (optional) deploy service in another namespace and check to see if you can make a connection to a service in the default namespace without adding `cluster.local`. 
- (optional) The service i deployed was shell demo (https://github.com/DecipherNow/openshift-development/blob/master/shell.yaml).  Once it is deployed exec into it and install telnet.  run the command `telnet redis.default.svc 6379`

you should see:
```
Trying 172.17.0.12...
Connected to redis.default.svc.cluster.local.
```
from here you can see that `.cluster.local` was automatically appended. 

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

none

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

https://18.216.181.118:31690/#/grey-matter-data-v1-00?ascending=true&configPaneOpen=false&configPaneService=&displayType=Cards&groupByAttribute=Status&searchQuery=&sortByAttribute=Name

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/21246992/68494252-1a314d80-021c-11ea-8c0e-67b42faa0301.png">

