### PR TITLE
Add the helm package greymatter actions

### DIFF
--- a/.github/workflows/release-pr-merged.yml
+++ b/.github/workflows/release-pr-merged.yml
@@ -1,0 +1,172 @@
+# This workflow is meant to run when a PR is closed, or merged.  It will attempt to
+# package and push all charts to Decipher's hosted repository.
+
+name: Grey Matter Release to Hosted
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'release-**'
+
+jobs:
+  PackageCatalog:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Catalog
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./catalog
+  PackageControl:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./control
+  PackageControlAPI:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./gm-control-api
+  PackageDashboard:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./dashboard
+  PackageJWT:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./jwt
+  PackageJWTGov:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-government/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./jwt-gov
+  PackageData:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./data
+  PackageEdge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./edge
+  PackageSlo:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./slo
+  PackageGreyMatter:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    needs:
+      [
+        PackageCatalog,
+        PackageSlo,
+        PackageEdge,
+        PackageData,
+        PackageJWT,
+        PackageJWTGov,
+        PackageDashboard,
+        PackageControlAPI,
+        PackageControl,
+        PackageCatalog,
+      ]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Grey Matter
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-hosted/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./greymatter
+  NotifySlackSuccess:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && success()
+    needs: PackageGreyMatter
+    steps:
+      - name: Slack notification
+        env:
+          SLACK_CHANNEL: 'decipher-sres-bots'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: GitHubActions
+          SLACK_ICON: https://raw.githubusercontent.com/quintessence/slack-icons/master/images/github-logo-slack-icon.png
+          SLACK_MESSAGE: 'Grey Matter Helm charts released to Hosted'
+        uses: rtCamp/action-slack-notify@master
+  NotifySlackFailure:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && failure()
+    needs: PackageGreyMatter
+    steps:
+      - name: Slack notification
+        env:
+          SLACK_CHANNEL: 'decipher-sres-bots'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: GitHubActions
+          SLACK_ICON: https://raw.githubusercontent.com/quintessence/slack-icons/master/images/github-logo-slack-icon.png
+          SLACK_MESSAGE: 'Grey Matter Helm charts failed to released to Hosted'
+          SLACK_COLOR: '#FF0000'
+        uses: rtCamp/action-slack-notify@master

--- a/.github/workflows/release-pr-opened.yml
+++ b/.github/workflows/release-pr-opened.yml
@@ -1,0 +1,184 @@
+# This workflow is meant to run when a PR is submitted.  It will attempt to
+# package and push all charts to Decipher's staging repository.
+
+name: Grey Matter Release to Staging
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - 'release-**'
+
+jobs:
+  PackageCatalog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Catalog
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./catalog
+
+  PackageControl:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./control
+
+  PackageControlAPI:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./gm-control-api
+
+  PackageDashboard:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./dashboard
+
+  PackageJWT:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./jwt
+
+  PackageJWTGov:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./jwt-gov
+
+  PackageData:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./data
+
+  PackageEdge:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./edge
+
+  PackageSlo:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v1
+      - name: Package Control
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./slo
+
+  PackageGreyMatter:
+    runs-on: ubuntu-latest
+    if: success()
+    needs:
+      [
+        PackageCatalog,
+        PackageSlo,
+        PackageEdge,
+        PackageData,
+        PackageJWT,
+        PackageJWTGov,
+        PackageDashboard,
+        PackageControlAPI,
+        PackageControl,
+        PackageCatalog,
+      ]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Point to Staging
+        run: |
+          sed -i "s/helm-hosted/helm-staging/g" greymatter/requirements.yaml
+      - name: Package Grey Matter
+        uses: deciphernow/greymatter-helm-action@master
+        with:
+          NEXUS_URL: https://nexus.production.deciphernow.com/repository/helm-staging/
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASS }}
+          args: ./greymatter
+
+  NotifySlackSuccess:
+    runs-on: ubuntu-latest
+    if: success()
+    needs: PackageGreyMatter
+    steps:
+      - name: Slack notification
+        env:
+          SLACK_CHANNEL: 'decipher-sres-bots'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: GitHubActions
+          SLACK_ICON: https://raw.githubusercontent.com/quintessence/slack-icons/master/images/github-logo-slack-icon.png
+          SLACK_MESSAGE: 'Grey Matter Helm charts released to Staging'
+        uses: rtCamp/action-slack-notify@master
+  NotifySlackFailure:
+    runs-on: ubuntu-latest
+    if: failure()
+    needs: PackageGreyMatter
+    steps:
+      - name: Slack notification
+        env:
+          SLACK_CHANNEL: 'decipher-sres-bots'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: GitHubActions
+          SLACK_ICON: https://raw.githubusercontent.com/quintessence/slack-icons/master/images/github-logo-slack-icon.png
+          SLACK_MESSAGE: 'Grey Matter Helm charts failed to released to Staging'
+          SLACK_COLOR: '#FF0000'
+        uses: rtCamp/action-slack-notify@master


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

This PR changes the CI from Jenkins to GitHub Actions. Since the repo is public, we can leverage the GitHub Actions.  There are two workflows in this PR
1. Runs a helm package when a PR is submitted.  Reports to the PR as a Status check
2. Runs a helm package and deploys to Nexus when the PR is merged

I did as much testing as I could in my own environment.

I do not think this is the end of the necessary updates  to use GitHub Actions, but this should get us rolling again now that dev has died.

The necessary secrets have been created, but not yet verified in this repo.

This uses the GitHub Action at https://github.com/DecipherNow/greymatter-helm-action