### PR TITLE
Enable Impersonation in the mesh

### DIFF
--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 2.1.1
+version: 2.1.2
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/edge/templates/_domain.tpl
+++ b/edge/templates/_domain.tpl
@@ -1,0 +1,7 @@
+{{- define "greymatter.domain" }}
+    {{- if .Values.global.remove_namespace_from_url  }}
+{{- .Values.global.route_url_name }}.{{ .Values.global.domain }}
+    {{- else }}
+{{- .Values.global.route_url_name }}.{{ .Release.Namespace }}.{{ .Values.global.domain }}
+    {{- end }}
+{{- end }}

--- a/edge/templates/_edge_volume_mounts.tpl
+++ b/edge/templates/_edge_volume_mounts.tpl
@@ -1,0 +1,11 @@
+{{- define "edge_spire_volume_mounts" }}
+- name: spire-agent-socket
+  mountPath: /run/spire/sockets
+  readOnly: true
+{{- end }}
+
+{{- define "edge_volume_certs_mount" }}
+- name: edge-egress
+  mountPath: /etc/proxy/tls/sidecar/
+  readOnly: true
+{{- end }}

--- a/edge/templates/_edge_volumes.tpl
+++ b/edge/templates/_edge_volumes.tpl
@@ -1,0 +1,12 @@
+{{- define "edge_spire_volumes" }}
+- name: spire-agent-socket
+  hostPath:
+    path: /run/spire/sockets
+    type: Directory
+{{- end }}
+
+{{- define "edge_certs_volumes" }}
+- name: edge-egress
+  secret:
+    secretName: {{ .Values.edge.certificates.egress.name }}
+{{- end }}

--- a/edge/templates/edge-secret.yaml
+++ b/edge/templates/edge-secret.yaml
@@ -1,23 +1,23 @@
 {{- if .Values.edge.create_edge_secret }}
-{{ if .Values.edge.certificates }}
-{{- with .Values.edge.certificates }}
+{{- if .Values.edge.certificates }}
+{{- range $name, $cert := .Values.edge.certificates }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .name }}
+  name: {{ $cert.name }}
   labels:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
 type: Opaque
 data:
-  ca.crt: {{ .ca | b64enc }}
-  ca_b64: {{ .ca | b64enc | b64enc }}
-  server.crt: {{ .cert | b64enc }}
-  cert_b64: {{ .cert | b64enc | b64enc }}
-  server.key: {{ .key | b64enc }}
-  key_b64: {{ .key | b64enc | b64enc }}
+  ca.crt: {{ $cert.ca | b64enc }}
+  ca_b64: {{ $cert.ca | b64enc | b64enc }}
+  server.crt: {{ $cert.cert | b64enc }}
+  cert_b64: {{ $cert.cert | b64enc | b64enc }}
+  server.key: {{ $cert.key | b64enc }}
+  key_b64: {{ $cert.key | b64enc | b64enc }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/edge/templates/edge.yaml
+++ b/edge/templates/edge.yaml
@@ -38,7 +38,7 @@ spec:
           mountPath: /run/spire/sockets
           readOnly: true
         {{- else if and (not .Values.global.spire.enabled) (.Values.global.mesh_tls.use_provided_certs) }}
-        {{- include "sidecar_volume_certs_mount" . | indent 8 }}
+        {{- include "edge_volume_certs_mount" . | indent 8 }}
         {{- end}}
       {{- if .Values.global.consul.enabled }}
       {{- $data := dict "Values" .Values "ServiceName" "edge" }}
@@ -55,12 +55,12 @@ spec:
       {{- end }}
       - name: edge
         secret:
-          secretName: edge
+          secretName: {{ .Values.edge.certificates.ingress.name}}
       {{- if .Values.global.spire.enabled }}
       - name: spire-agent-socket
         hostPath:
           path: /run/spire/sockets
           type: Directory
       {{- else if and (not .Values.global.spire.enabled) (.Values.global.mesh_tls.use_provided_certs) }}
-      {{- include "sidecar_certs_volumes" . | indent 6 }}
+      {{- include "edge_certs_volumes" . | indent 6 }}
       {{- end }}

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -14,6 +14,7 @@ global:
   edge:
     enableTLS: true
     certPath: /etc/proxy/tls/edge
+    egressDn: cn=edge
   consul:
     enabled: false
     host: ''
@@ -40,22 +41,39 @@ edge:
       cpu: 100m
       memory: 128Mi
 
-  # These are the certs that the edge will use for ingress traffic into the mesh
+  # The edge requires two certifiates.  One for ingress traffic from the internet and another
+  # for egress traffic into the mesh.  The egress cert needs to be specific to the edge so 
+  # impersonation can be configured to all of the services from the edge service
   create_edge_secret: false
   certificates:
-    name: edge
-    ca: |-
-      -----BEGIN CERTIFICATE-----
-      ...
-      -----END CERTIFICATE-----
-    cert: |-
-      -----BEGIN CERTIFICATE-----
-      ...
-      -----END CERTIFICATE-----
-    key: |-
-      -----BEGIN RSA PRIVATE KEY-----
-      ...
-      -----END RSA PRIVATE KEY-----
+    ingress:
+      name: greymatter-edge-ingress
+      ca: |-
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      cert: |-
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      key: |-
+        -----BEGIN RSA PRIVATE KEY-----
+        ...
+        -----END RSA PRIVATE KEY-----
+    egress:
+      name: greymatter-edge-egress
+      ca: |-
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      cert: |-
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      key: |-
+        -----BEGIN RSA PRIVATE KEY-----
+        ...
+        -----END RSA PRIVATE KEY-----
 
 sidecar:
   version: '{{- $.Values.global.edge.version | default $.Values.global.sidecar.version }}'

--- a/gm-control-api/Chart.yaml
+++ b/gm-control-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.0.2
 description: Deploys the Grey Matter 2.0 gm-control-api mesh-wide configuration API
 name: gm-control-api
-version: 2.1.3
+version: 2.1.4

--- a/gm-control-api/json/services/proxy.json
+++ b/gm-control-api/json/services/proxy.json
@@ -13,7 +13,10 @@
   {{- if (.service.observablesEnabled) }}
     "gm.observables",
   {{- end }}
-    "gm.metrics" 
+  {{- if .Values.global.mesh_tls.enabled }}
+    "gm.impersonation",
+  {{- end }}
+    "gm.metrics"
   ],
   "proxy_filters": {
     {{-  if (.service.observablesEnabled) }}
@@ -22,6 +25,11 @@
       "topic": "{{.service.serviceName}}",
       "eventTopic": "{{ .Values.global.observables.topic }}",
       "kafkaServerConnection": "{{ .Values.global.observables.kafkaServerConnection }}"
+    },
+    {{- end }}
+    {{- if .Values.global.mesh_tls.enabled }}
+    "gm_impersonation": {
+      "servers": "{{ .Values.global.edge.egressDn }}{{- if not (eq .service.serviceName "dashboard") -}}|{{ .Values.global.mesh_tls.dn }}{{- end -}}"
     },
     {{- end }}
     "gm_metrics": {

--- a/greymatter-secrets.yaml
+++ b/greymatter-secrets.yaml
@@ -1519,151 +1519,300 @@ sidecar:
 
 edge:
   edge:
+    # This is a map of certificates that will be loaded into the edge service.
+    # - Edge ingress represents the certificates presented to clients that attempt
+    #   to gain access to the mesh from the external world
+    # - Edge egress represents the certificates that edge will use to talk to the
+    #   mesh. These certificates need to be issued from the same CA for certificates
+    #   of the other sidecars, so they accept this certificate
     certificates:
-      name: edge
-      ca: |-
-        -----BEGIN CERTIFICATE-----
-        MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT
-        MREwDwYDVQQIDAhWaXJnaW5pYTETMBEGA1UEBwwKQWxleGFuZHJpYTEkMCIGA1UE
-        CgwbRGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVl
-        cmluZzEuMCwGA1UEAwwlRGVjaXBoZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChS
-        b290KTEqMCgGCSqGSIb3DQEJARYbZW5naW5lZXJpbmdAZGVjaXBoZXJub3cuY29t
-        MB4XDTE3MDgwOTExMjMwOFoXDTI3MDgwNzExMjMwOFowgcAxCzAJBgNVBAYTAlVT
-        MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
-        eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
-        ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
-        hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wggIiMA0GCSqGSIb3
-        DQEBAQUAA4ICDwAwggIKAoICAQDPkxaiUD3uqR2AA5jwAb9gCjD+BrOrYBoelnR6
-        u29FPT5cHeM8bfVo6zixy7qC2lXzhK5gH/TLWXelpEwU+sw81oUbzZlB7Z2lvpj8
-        t4zXg4zgHNPqAFJM6L9b70dLgukhcUO6nnIiPPAprmtBDvXbtBwDCzOPaMcBeEwi
-        zERa4WyXYjn5Q+a8LTTLQ/OFmLHFA2dCG78s6cYQOfF92L641QdOhqXPtq+QwqAm
-        WkQ53Pes6rHmjT0kC8hEI5fCKEA3QXYt6YtgX+KIHgOYWI0g22wh95ohk+DuRL/O
-        3zzJ9tCjrMPO2lxmg0GdpuqjfR6K8CEk4Yq2dUwYC7dffgCrWv9zik/pXeoSvTv3
-        XprMN2WWKBX9lVC2qKFhNX4driBFRO0i5+bGdM1e8NilUDqHiikwhaVx2znb/E/b
-        LCCwlhC0oAAxnVZ1J18k46STe7hlg/RqM/18uxmhP9an2FkDtuyZBugbpWpgk7lE
-        tpOd92iCGYDc6k8Jsn+p0UiZjioJv/Gm04T3t90dkVu7D+mwFIsEAaJjwepEZ7ki
-        IBayWrJml+DT4ghyadkms8UaOa+YOYEZiY5GzJhEodAt01OanSkzR/FYjM4SuGXw
-        Rrq2p8hTuUBBm1p9ipv8DLqPmlXZ2Cn7ByTX7TMsG+77R4zkka5XD5tULpAf5xKo
-        qx4N/QIDAQABo2YwZDAdBgNVHQ4EFgQUbA2I9pZUJ7Z6WxXfTRecoCsqfnUwHwYD
-        VR0jBBgwFoAUY5U4Jb8hC6Ssinh2LzCB3tly8bcwEgYDVR0TAQH/BAgwBgEB/wIB
-        ADAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAHMtenslnEuvnT4g
-        JWR70FZv3wUOOqAsyxJdWj4o8yM7/V3wGKMxkRv7Oqetp92XYauffSPxE3INnGMq
-        DdRMTf2MGVnv/W5PJouZwMhBX4W6rjvl4QCSl+Q+wSt+OibNu2AxdCeQKa67cwvf
-        QfD4ufeWfvUPzazwzuJqE5WCjNnM2KsWbmzclquAbUjKH0017UGRYe8THrCZ5Mdn
-        L9X+ZSe5wWHWIm7JLn5nexeW668hgcdINrKBRg7ygKWrO/aMFnl3cQXmbNtXBt+y
-        E5tof618/HWJBjC3e+eyIMqjgjEZmxYfxwBTk0XVEZuA3PyAGigA17Q0ev5Zx4ii
-        2fGIYN5y3L6OMrfkcmdtihoQisqd+zKlgxWH4Z2KtV0RFVTreooNaSpFZu6EeCPH
-        0fg++TV/uGOEfNc4seEfFiaM4uq8mp5E1PYOXX4DLkzignqql9h8u3/3ZC7m4NoY
-        qpoOurQyY/dCUIJw3Kb+Dlck1OZsGQNvkpflHvCxCvTq48bEgjO+xkoYBODhY0wT
-        grl1kFBXMNNAiFiHlHaM6h+MKv/9cRi63KXmhiEjUWUVcdT9ZRRPJ6qd5QAJHJ+h
-        NU7s17ar5/4SgJx9BZSEYzQQCzt4REwBxfrF/GdGNia1wZcqMNylmkD8fCWBZiW2
-        sarsDzVzwvduL1ODIycXxe/pZUxi
-        -----END CERTIFICATE-----
-        -----BEGIN CERTIFICATE-----
-        MIIGgjCCBGqgAwIBAgIJAKBdlRUnXXIJMA0GCSqGSIb3DQEBCwUAMIHNMQswCQYD
-        VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
-        JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
-        RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
-        cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
-        bm93LmNvbTAeFw0xNzA4MDkxMTIyMTlaFw0yNzA4MDcxMTIyMTlaMIHNMQswCQYD
-        VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
-        JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
-        RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
-        cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
-        bm93LmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALDo08zRbssi
-        vrgIyCiE3x5ttHDcEsOs3EaZaE3hHpXK5an5iXT8/tl35BDAWl1J6CJkm4ip0Ch5
-        jOqrk5peQJKuN731GlafzoabwHcqyD6CvJZANre64s0J2CTZpob2gWM06C75uwzK
-        5W4JfivSzBpHu8A+FJARmZpnQoFDRIPWQFk9q22CPIWtlUdrkwVdnHlV++hRKKBU
-        qwAyXj6UUnrvwWNER0C0wksoJf+5oP/HLyqzUcd6yPmOiAe8QhR8jLdt/K8e14GI
-        7XhAytKxI2qHqzUmi2T57lIzz83fG4Cmo59mIF4jLvHfjC48zz9dCoObCK/QcczX
-        lipxmTm9HocDWCCo0L035arvWxRkP8ec75CE20Q8RqUY9jQo4a64RydbAabCw8s0
-        b0mSoHbRvpZCx96KhCG7EkjCorWrvh9dxZAenIZDAbn3sX9QGc6A+B5MYbv70UKo
-        8RD2IODsvuCSnn1rEQpGb0d6hNSReDN2cYLnSeuoMUlxT/SRCNBizGOWxJuFL1Cr
-        5YnNyUv3tCEXKxEM9OoRHutydmeg8fTbTu8hAlGiYhgqehmkApS25qCl4sVz3FUj
-        /y2yfQbecliu/YdPVziRGsLOTGhQldBSIaVdMGA/muzxVtOJdLBuK/qK/gvW7N2s
-        vZQTHZz+B10Dlxs9S2Nhf7FX7pMLM9hXAgMBAAGjYzBhMB0GA1UdDgQWBBRjlTgl
-        vyELpKyKeHYvMIHe2XLxtzAfBgNVHSMEGDAWgBRjlTglvyELpKyKeHYvMIHe2XLx
-        tzAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsF
-        AAOCAgEAcB4z4ALRX+s1Fb1j2sWLo65jIyxm0OB2RTlhstd4+zd+zFjLg7XE0O5j
-        Ilm3basVlLM2mTmi5CC4mvOBibSb6NlJr34GmKbfwYVLj3tpnlnA/HGGzHY3uoX6
-        zBUSIYRH10k2bmpM438fXtz9P+kHAkmsVj2Yk8uLg+tZDZEdM8qiWbaIZa+awHwL
-        DBhd1dQ7ZyejVJLKGyYwd7dMYLq04F4AqawPp2ksmcUtktU2Q+uGmJBkqgBzUTC+
-        64yPKBbPa2WFFDVtqt0r6qD2N7FD6v0b0PiBeruvhpSva1yvE0vMNfa9kc8ExrKz
-        7GMMGsv3TIOqK0tYXJayoM+8VAELwBcFvkCkobs4TtkF3VoPiO91hlm7K+7woNQH
-        OVhxqDqH3ECA7vNLeA09xT7EApXzPGwk163O4qoZdT7VUI2Fu9G0+IzzS42TVXOm
-        MUp1sEidUUElwuuqDvKxsBP6do9xT8dHg2n9Y04ME2FyQ1omuLzRrcyjU6Qo6PLr
-        H/di6KT3iiZ/leFkDMf5/Pesy7bExPZN2sHR3SpR5RwQh50T4KZx7FOqvCJpi6Pp
-        H1cz0921qGtG0iheOzWfonmvYKnhxcTTpg+fuiVdPWwdutjVl+HPc2yjw1Gdqw4h
-        n4oFjG4KQO6zvZzGDFay9HazZyUKpgamy24u8XY7/BSWc1c95Gg=
-        -----END CERTIFICATE-----
-      cert: |-
-        -----BEGIN CERTIFICATE-----
-        MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
-        MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
-        eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
-        ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
-        hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
-        MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
-        Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
-        RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
-        MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
-        AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
-        l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
-        uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
-        RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
-        dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
-        RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
-        BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
-        blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
-        6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
-        Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
-        EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
-        IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
-        ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
-        bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
-        BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
-        bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
-        dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
-        zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
-        Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
-        8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
-        IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
-        eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
-        cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
-        wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
-        dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
-        XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
-        fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
-        -----END CERTIFICATE-----
-      key: |-
-        -----BEGIN RSA PRIVATE KEY-----
-        MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
-        p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
-        biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
-        kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
-        JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
-        xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
-        UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
-        FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
-        AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
-        ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
-        pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
-        lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
-        fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
-        Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
-        SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
-        qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
-        Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
-        6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
-        keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
-        ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
-        HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
-        pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
-        vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
-        P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
-        zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
-        -----END RSA PRIVATE KEY-----
-        
+      ingress:
+        name: greymatter-edge-ingress
+        ca: |-
+          -----BEGIN CERTIFICATE-----
+          MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT
+          MREwDwYDVQQIDAhWaXJnaW5pYTETMBEGA1UEBwwKQWxleGFuZHJpYTEkMCIGA1UE
+          CgwbRGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVl
+          cmluZzEuMCwGA1UEAwwlRGVjaXBoZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChS
+          b290KTEqMCgGCSqGSIb3DQEJARYbZW5naW5lZXJpbmdAZGVjaXBoZXJub3cuY29t
+          MB4XDTE3MDgwOTExMjMwOFoXDTI3MDgwNzExMjMwOFowgcAxCzAJBgNVBAYTAlVT
+          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wggIiMA0GCSqGSIb3
+          DQEBAQUAA4ICDwAwggIKAoICAQDPkxaiUD3uqR2AA5jwAb9gCjD+BrOrYBoelnR6
+          u29FPT5cHeM8bfVo6zixy7qC2lXzhK5gH/TLWXelpEwU+sw81oUbzZlB7Z2lvpj8
+          t4zXg4zgHNPqAFJM6L9b70dLgukhcUO6nnIiPPAprmtBDvXbtBwDCzOPaMcBeEwi
+          zERa4WyXYjn5Q+a8LTTLQ/OFmLHFA2dCG78s6cYQOfF92L641QdOhqXPtq+QwqAm
+          WkQ53Pes6rHmjT0kC8hEI5fCKEA3QXYt6YtgX+KIHgOYWI0g22wh95ohk+DuRL/O
+          3zzJ9tCjrMPO2lxmg0GdpuqjfR6K8CEk4Yq2dUwYC7dffgCrWv9zik/pXeoSvTv3
+          XprMN2WWKBX9lVC2qKFhNX4driBFRO0i5+bGdM1e8NilUDqHiikwhaVx2znb/E/b
+          LCCwlhC0oAAxnVZ1J18k46STe7hlg/RqM/18uxmhP9an2FkDtuyZBugbpWpgk7lE
+          tpOd92iCGYDc6k8Jsn+p0UiZjioJv/Gm04T3t90dkVu7D+mwFIsEAaJjwepEZ7ki
+          IBayWrJml+DT4ghyadkms8UaOa+YOYEZiY5GzJhEodAt01OanSkzR/FYjM4SuGXw
+          Rrq2p8hTuUBBm1p9ipv8DLqPmlXZ2Cn7ByTX7TMsG+77R4zkka5XD5tULpAf5xKo
+          qx4N/QIDAQABo2YwZDAdBgNVHQ4EFgQUbA2I9pZUJ7Z6WxXfTRecoCsqfnUwHwYD
+          VR0jBBgwFoAUY5U4Jb8hC6Ssinh2LzCB3tly8bcwEgYDVR0TAQH/BAgwBgEB/wIB
+          ADAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAHMtenslnEuvnT4g
+          JWR70FZv3wUOOqAsyxJdWj4o8yM7/V3wGKMxkRv7Oqetp92XYauffSPxE3INnGMq
+          DdRMTf2MGVnv/W5PJouZwMhBX4W6rjvl4QCSl+Q+wSt+OibNu2AxdCeQKa67cwvf
+          QfD4ufeWfvUPzazwzuJqE5WCjNnM2KsWbmzclquAbUjKH0017UGRYe8THrCZ5Mdn
+          L9X+ZSe5wWHWIm7JLn5nexeW668hgcdINrKBRg7ygKWrO/aMFnl3cQXmbNtXBt+y
+          E5tof618/HWJBjC3e+eyIMqjgjEZmxYfxwBTk0XVEZuA3PyAGigA17Q0ev5Zx4ii
+          2fGIYN5y3L6OMrfkcmdtihoQisqd+zKlgxWH4Z2KtV0RFVTreooNaSpFZu6EeCPH
+          0fg++TV/uGOEfNc4seEfFiaM4uq8mp5E1PYOXX4DLkzignqql9h8u3/3ZC7m4NoY
+          qpoOurQyY/dCUIJw3Kb+Dlck1OZsGQNvkpflHvCxCvTq48bEgjO+xkoYBODhY0wT
+          grl1kFBXMNNAiFiHlHaM6h+MKv/9cRi63KXmhiEjUWUVcdT9ZRRPJ6qd5QAJHJ+h
+          NU7s17ar5/4SgJx9BZSEYzQQCzt4REwBxfrF/GdGNia1wZcqMNylmkD8fCWBZiW2
+          sarsDzVzwvduL1ODIycXxe/pZUxi
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          MIIGgjCCBGqgAwIBAgIJAKBdlRUnXXIJMA0GCSqGSIb3DQEBCwUAMIHNMQswCQYD
+          VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
+          JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
+          RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
+          cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
+          bm93LmNvbTAeFw0xNzA4MDkxMTIyMTlaFw0yNzA4MDcxMTIyMTlaMIHNMQswCQYD
+          VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
+          JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
+          RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
+          cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
+          bm93LmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALDo08zRbssi
+          vrgIyCiE3x5ttHDcEsOs3EaZaE3hHpXK5an5iXT8/tl35BDAWl1J6CJkm4ip0Ch5
+          jOqrk5peQJKuN731GlafzoabwHcqyD6CvJZANre64s0J2CTZpob2gWM06C75uwzK
+          5W4JfivSzBpHu8A+FJARmZpnQoFDRIPWQFk9q22CPIWtlUdrkwVdnHlV++hRKKBU
+          qwAyXj6UUnrvwWNER0C0wksoJf+5oP/HLyqzUcd6yPmOiAe8QhR8jLdt/K8e14GI
+          7XhAytKxI2qHqzUmi2T57lIzz83fG4Cmo59mIF4jLvHfjC48zz9dCoObCK/QcczX
+          lipxmTm9HocDWCCo0L035arvWxRkP8ec75CE20Q8RqUY9jQo4a64RydbAabCw8s0
+          b0mSoHbRvpZCx96KhCG7EkjCorWrvh9dxZAenIZDAbn3sX9QGc6A+B5MYbv70UKo
+          8RD2IODsvuCSnn1rEQpGb0d6hNSReDN2cYLnSeuoMUlxT/SRCNBizGOWxJuFL1Cr
+          5YnNyUv3tCEXKxEM9OoRHutydmeg8fTbTu8hAlGiYhgqehmkApS25qCl4sVz3FUj
+          /y2yfQbecliu/YdPVziRGsLOTGhQldBSIaVdMGA/muzxVtOJdLBuK/qK/gvW7N2s
+          vZQTHZz+B10Dlxs9S2Nhf7FX7pMLM9hXAgMBAAGjYzBhMB0GA1UdDgQWBBRjlTgl
+          vyELpKyKeHYvMIHe2XLxtzAfBgNVHSMEGDAWgBRjlTglvyELpKyKeHYvMIHe2XLx
+          tzAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsF
+          AAOCAgEAcB4z4ALRX+s1Fb1j2sWLo65jIyxm0OB2RTlhstd4+zd+zFjLg7XE0O5j
+          Ilm3basVlLM2mTmi5CC4mvOBibSb6NlJr34GmKbfwYVLj3tpnlnA/HGGzHY3uoX6
+          zBUSIYRH10k2bmpM438fXtz9P+kHAkmsVj2Yk8uLg+tZDZEdM8qiWbaIZa+awHwL
+          DBhd1dQ7ZyejVJLKGyYwd7dMYLq04F4AqawPp2ksmcUtktU2Q+uGmJBkqgBzUTC+
+          64yPKBbPa2WFFDVtqt0r6qD2N7FD6v0b0PiBeruvhpSva1yvE0vMNfa9kc8ExrKz
+          7GMMGsv3TIOqK0tYXJayoM+8VAELwBcFvkCkobs4TtkF3VoPiO91hlm7K+7woNQH
+          OVhxqDqH3ECA7vNLeA09xT7EApXzPGwk163O4qoZdT7VUI2Fu9G0+IzzS42TVXOm
+          MUp1sEidUUElwuuqDvKxsBP6do9xT8dHg2n9Y04ME2FyQ1omuLzRrcyjU6Qo6PLr
+          H/di6KT3iiZ/leFkDMf5/Pesy7bExPZN2sHR3SpR5RwQh50T4KZx7FOqvCJpi6Pp
+          H1cz0921qGtG0iheOzWfonmvYKnhxcTTpg+fuiVdPWwdutjVl+HPc2yjw1Gdqw4h
+          n4oFjG4KQO6zvZzGDFay9HazZyUKpgamy24u8XY7/BSWc1c95Gg=
+          -----END CERTIFICATE-----
+        cert: |-
+          -----BEGIN CERTIFICATE-----
+          MIIGqDCCBJCgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
+          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkwMjIzMTY0
+          MDA1WhcNMjkwMjIwMTY0MDA1WjCBmjEnMCUGA1UEAwweKi5ncmV5bWF0dGVyLnN2
+          Yy5jbHVzdGVyLmxvY2FsMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEkMCIGA1UECgwb
+          RGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRMwEQYDVQQHDApBbGV4YW5kcmlh
+          MREwDwYDVQQIDAhWaXJnaW5pYTELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEB
+          AQUAA4IBDwAwggEKAoIBAQDYV8wHf/ClTnpyBwUlJltXAL6o4I/tim9KmFUuCm24
+          l0mjhmyn/bcPE6bD7U1u7Wn8iFk9pmF2o/h6BWboPf+72SV3oSzIfrPfOHn4NFVM
+          uF9eGqluIyYW++Njgn4WBKrFj/5q+MFSC/BpME8z9ZetMRxzsnf6RSGipT38xnzL
+          RN5zxDyR0zc4Dq8sU+oMAuOKTO3fNCRKPeJiG3X7QhK1kpSApZay8vEWrwTlzN4B
+          dx6jRRMkq1lw/33DrStFT3dzOQab1ZCpC/KqTIXf7IOv6g+FDQQrNaU43/BjxvYK
+          RC+oTM3FvxoqEyZUEd/xdO1QhAkEoJ9PTXb5aEbwZ1KNAgMBAAGjggHOMIIByjAJ
+          BgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGwDAzBglghkgBhvhCAQ0EJhYkT3Bl
+          blNTTCBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0GA1UdDgQWBBRvU9+t
+          6UuwQx8FlqO/IfS7daM61zCB+wYDVR0jBIHzMIHwgBRsDYj2llQntnpbFd9NF5yg
+          Kyp+daGB06SB0DCBzTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCFZpcmdpbmlhMRMw
+          EQYDVQQHDApBbGV4YW5kcmlhMSQwIgYDVQQKDBtEZWNpcGhlciBUZWNobm9sb2d5
+          IFN0dWRpb3MxFDASBgNVBAsMC0VuZ2luZWVyaW5nMS4wLAYDVQQDDCVEZWNpcGhl
+          ciBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgKFJvb3QpMSowKAYJKoZIhvcNAQkBFhtl
+          bmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb22CAhAAMA4GA1UdDwEB/wQEAwIFoDAd
+          BgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwKQYDVR0RBCIwIIIeKi5ncmV5
+          bWF0dGVyLnN2Yy5jbHVzdGVyLmxvY2FsMA0GCSqGSIb3DQEBCwUAA4ICAQDGLScK
+          dAl4koDgJ0UiQcGL8lJIsq9qRg4yx8qacUFLx+wzdY6CJKQu1nMDgaK7csHXmlIX
+          zkIMOtp6pv/p2UQBqubsbXnKlGqYt9DSBPOp+/0t/CdjUW3Jg0MMR59NhKTGzAk7
+          Zu9+dkYhVR2nMvI12X2I4TY3s2LICG7iWXSRaoTbqaPPb3OUB91n7qaW3re1P1c0
+          8BlaZJNNq3GclDZNIxBY2Vh+n3aubzyVDRo7KZE/+XBddV3bR8piLUh68unn00lx
+          IHl0tcscn/zU8xykpaI6HUAHbxMtoPWqbaIBr+cKIF4iwSOEgT3jzBHk8jiktuCk
+          eTq2ErI0dllqte2k6OWQfa5s0CXJnI+Xf/jzUx/LnA5zv8nWhNl18nRS7rKgVNfv
+          cyxtSIXex1lIoyTzkxpOvxHwifPZ1w4LbpTRscVArC+2ntKd0Z+1Vla8BIEzgX9H
+          wakUkhRzzlXDnEfiEDn8jFtohNGJTL4SZqVF0rR9FeGvYjVUnT5CM3fVgNev873d
+          dUSBqcKzerM7ileeL43ceRdyE6ylrMUH2rCx4dxxlY6Dbz9kzDvvl494vB8T2rl7
+          XunCxj+01VSZBWzHG4C6ENbLtk9B5MKr78MAyuMxDSDf9ynxlTDLAOjagIne/nTP
+          fG1J+3TYy8M6dI9gUwjE2v87xt9jJY2lDofLhQ==
+          -----END CERTIFICATE-----
+        key: |-
+          -----BEGIN RSA PRIVATE KEY-----
+          MIIEpQIBAAKCAQEA2FfMB3/wpU56cgcFJSZbVwC+qOCP7YpvSphVLgptuJdJo4Zs
+          p/23DxOmw+1Nbu1p/IhZPaZhdqP4egVm6D3/u9kld6EsyH6z3zh5+DRVTLhfXhqp
+          biMmFvvjY4J+FgSqxY/+avjBUgvwaTBPM/WXrTEcc7J3+kUhoqU9/MZ8y0Tec8Q8
+          kdM3OA6vLFPqDALjikzt3zQkSj3iYht1+0IStZKUgKWWsvLxFq8E5czeAXceo0UT
+          JKtZcP99w60rRU93czkGm9WQqQvyqkyF3+yDr+oPhQ0EKzWlON/wY8b2CkQvqEzN
+          xb8aKhMmVBHf8XTtUIQJBKCfT012+WhG8GdSjQIDAQABAoIBAC2Ew4PscliFm5O0
+          UGvRlzRGDtd/cCj9kI70YC+wuAc3paHHXcM2ybZdXyAoJLurLjqZAZXMFQOeWmBq
+          FI3WxaDjflOeUMrahcP4oQkNEclznXUyTOXEdXYuh1hfk2HUl427zz74mcxGgM3R
+          AUkgakphY+gf68h3lS0gcVtm88jckJxt263b/Z1zr4Hxwx57XV352s+NY/uVkwZh
+          ihRo6Gy8AOO1Fjx/1Yucs6J3GF0DTfjCF2f5h/nPbTYSWitf9OXJR28wF+NfgwuW
+          pEob2h3yD4c+hWIEKrkwNeRFp7VLDJxT5IiubUqVsUBddYWZ0AOpsCV5XvUSnctT
+          lxJu4m0CgYEA7VPoZK/uuwk0nGqBv65FnA7gukgQGtDRW1L2yo6PrfzCAXyI1f+K
+          fkQ9yCzYARKs+rDQCdsXyTHYriLsP/cFT2wZdbjZznN/Sp1Z+FvN0I+LDanYNPz1
+          Zu+Sezp/3rSzdKWMdnX62KCRlwyRIfGHXyxj6Lpk3JAtbpOHM/0LY28CgYEA6V06
+          SLqYbpD3DgefUDd8Q/xIJreIq7gI/Irou0fOsLxfElgCppF4CvCND/U5psZvMC48
+          qxWv27WOFzUU57WMfGTzPveGklaudN0SouO/kNb1sd7OnO6w4ppqpCRBPk3iPCVB
+          Wv7XGbuA23Pcfr7xQcW07q4M97SuP0dZr9QwO8MCgYEAjuKCuwQVRjRfoYCaR25D
+          6JYohN7YG1z3fvUvMnqsVIMlxsFUnQqyNh0d2UPudI7q6C/FwPlQk8hX/Vd3R3eQ
+          keWyWmcFcz+kNqcPwPB8tIGHpZ1JV3WoxeWdGmX5EHtYw/Tb4YJcmUnq/bcKNhZ1
+          ez59lGOMUCLZx4Y403sY/S8CgYEA5/YSNC69y9FusVRkSEEO1SkUst9mC4Jf9F9D
+          HL0wtz5Wpg4zfExGbWFUZhNUHfFKnjKnfUuORS7/MRRDVlqAbTmPC/zQl+9vc5w3
+          pRAK37a7+/TDnPwpeOUSsVuUOpECGtTRVNjRCLP3Tquo9Zdoif8ybLk3DJVdSmrq
+          vDqHQy8CgYEA4il9jH7ynOw2OHQbD+XcLxKfzjZtXq3DCiXNh9+8KwW5XyDcmh/r
+          P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
+          zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
+          -----END RSA PRIVATE KEY-----
+      egress:
+        name: greymatter-edge-egress
+        cert: |-
+          -----BEGIN CERTIFICATE-----
+          MIIGdDCCBFygAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgcAxCzAJBgNVBAYTAlVT
+          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wHhcNMTkxMTIwMTQz
+          OTM0WhcNMjkxMTE3MTQzOTM0WjCBgDENMAsGA1UEAwwEZWRnZTEUMBIGA1UECwwL
+          RW5naW5lZXJpbmcxJDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlv
+          czETMBEGA1UEBwwKQWxleGFuZHJpYTERMA8GA1UECAwIVmlyZ2luaWExCzAJBgNV
+          BAYTAlVTMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5CsFZgozl7sD
+          OogSuUIzKlc+wvC+FyS0cGN1+2Y5fnf0G7N/yjwHLVOKigiykFEzf+e+3NKdD6KF
+          F3pdAeO6JDMmjzJqZVAZloLZbMW76axD9SEnVF4fti4grXWn5qHvsLztK9t3GeZm
+          TfQD/HJ2fEIKbFijp672GKIpp5Carioh8hX2qtUP+9tARXQ9Piri4QZ/I5b4te19
+          umFzkpZnt3YwdL8TZR460j0+inEMnuknQPMgR5tKyLbzX6EHsaxi7fP15Y73k/EC
+          xCXsYacc/MvDIduJnIu2IqW7bZrCjKFiE3i4OiPZ//2omp9Dutm2npA0/lxhZxPQ
+          7NWKWDLGPwIDAQABo4IBtDCCAbAwCQYDVR0TBAIwADARBglghkgBhvhCAQEEBAMC
+          BsAwMwYJYIZIAYb4QgENBCYWJE9wZW5TU0wgR2VuZXJhdGVkIFNlcnZlciBDZXJ0
+          aWZpY2F0ZTAdBgNVHQ4EFgQUhE12BiP8comHJf2VjSeM0FTjRG4wgfsGA1UdIwSB
+          8zCB8IAUbA2I9pZUJ7Z6WxXfTRecoCsqfnWhgdOkgdAwgc0xCzAJBgNVBAYTAlVT
+          MREwDwYDVQQIDAhWaXJnaW5pYTETMBEGA1UEBwwKQWxleGFuZHJpYTEkMCIGA1UE
+          CgwbRGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVl
+          cmluZzEuMCwGA1UEAwwlRGVjaXBoZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChS
+          b290KTEqMCgGCSqGSIb3DQEJARYbZW5naW5lZXJpbmdAZGVjaXBoZXJub3cuY29t
+          ggIQADAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUF
+          BwMBMA8GA1UdEQQIMAaCBGVkZ2UwDQYJKoZIhvcNAQELBQADggIBAEe0Xwwj3LS8
+          q26iwFW/e5EwxSAHIYj/uwXKYJnONGeWz4UOevN/F+W9YuuZWqGugKYmYrjiamUL
+          FsrqQNGy3cj2rACfFmA6jlQ7zuOYtLayYoaFuQw06Mu226QYD3BAPgN1YtEHCxKe
+          8dHxgA4NG4jkW4F2dazqxNcHUIbL+LN2MBs3cqmIOTyNbJ2AM/vT3RdoxPpKP+Ie
+          3mpKUiW+6KFqNzgs0QVb1j4oqmnFjLS0XOOVaaMyO9USfYg7XxtIj0ZkQG7tTU5m
+          +O1c2BIjICsfJl5FdqDmpUwMn42+JBfOQQzrnUt350YW/5LZcqp6WwfQNROGpRfo
+          5rId6Dd1K4C+BFf39gtzcPEpj7jmOHJ37jzWvD4ZBmtKdTU/Z0DHhXN/XkqInb0h
+          WUTCIJAHG8E5cIclV9o4r4RnblLam9VOFGxSRmIWJJ3w7zc834yKjnjOvIMC4opN
+          nTgCjGM3khuCX+kmsqARkwS7JCOOl8Myqv8NtG395rf3jmRBUYR8Tz4dq8LDIkoI
+          ndlsidlwsOxUoDUybihz7Brv2Lisc1hG41Zt7l0GmcGG2evp5CLcqf9CB/e3P7xL
+          bgd0TuCMvRtAvcXDDE+tjmaCoy1LgQ8Sq1aoJ5ZjKyei4McqLvJbDi7MeNdDviCt
+          GhHND4WowGuft6YGJ687dY37PWwv4mSp
+          -----END CERTIFICATE-----
+        key: |-
+          -----BEGIN RSA PRIVATE KEY-----
+          MIIEpAIBAAKCAQEA5CsFZgozl7sDOogSuUIzKlc+wvC+FyS0cGN1+2Y5fnf0G7N/
+          yjwHLVOKigiykFEzf+e+3NKdD6KFF3pdAeO6JDMmjzJqZVAZloLZbMW76axD9SEn
+          VF4fti4grXWn5qHvsLztK9t3GeZmTfQD/HJ2fEIKbFijp672GKIpp5Carioh8hX2
+          qtUP+9tARXQ9Piri4QZ/I5b4te19umFzkpZnt3YwdL8TZR460j0+inEMnuknQPMg
+          R5tKyLbzX6EHsaxi7fP15Y73k/ECxCXsYacc/MvDIduJnIu2IqW7bZrCjKFiE3i4
+          OiPZ//2omp9Dutm2npA0/lxhZxPQ7NWKWDLGPwIDAQABAoIBACF5ilY5Iu6c2lFp
+          C04wvy70E9on1cuxb+OZRAL5MXAzixXRVOtHuUnWGto7gm8X6rVWO7NMFwznLB2Q
+          rzqKvZF4C60wmVl50fc6BUonDHWw91tsXMfM81wYEmVAgLyef3rvjOBFV4juO44u
+          QbN025tJWRwiOQht698bU38pAPiSIOhV5gQLaleUraIfJNLLpEvqF1tucs4CfSOE
+          lQ9KSSpF3IQUcJWgp62i0StK+ylJx8dhyU6PgtZlI55lnsv4rHIUoebMWC+4k86J
+          4WPQrAx9oVb0TQdKhxRpwWrvGX9ZOGtCE/LseohfzSJX5Qz+ECId4za3xzzhly1o
+          LV8AFqkCgYEA+payvCBa4r29Xu+MQO5z7TBvcwSYZd7xiieB2BawIZheL9DI5DGh
+          dOm9R7K3LfA0rbojGr7gJk9L4fJWi95qtqsUOBRHj8QwIOiSYhbCKBDO5ASSJVJj
+          /Z4KiE2Y1c1FFtMAWkOzZrYxyvKJQl7VW24RLZ1/6DUvSjxAcZ/95asCgYEA6Rhg
+          ov4ZMqycNeAfcnLLTH/URxu5h0yGqgIsdWMMk0QaFbqlu3yevQ+ZUQTTLZ5b1oze
+          OJd8dNucsmNGCDrlODWIYparrQjzS8u3U4GbctPSHb9jwEN1HCaLVe6oUekrXP99
+          5khu3gg1vX1aGgs7yUd/7N7MSVvU7BrOlgMrpb0CgYEAxhsLNIUTtPux0XLp249o
+          IJTRFwoD/U1SgRkYop/VIMoXdA/IMfc2oHoFRMB55pxm2Q01oXhTNpYr9HWkjDEL
+          BlybwHXv2S2NqwaSa294kTowhb1DWLQZDrC5vOYztJrySsgHGFU7aDETjlFNyCW2
+          4PBULk68hvQ87aBShkGo9L8CgYBMePfzYYPo0SJqtn36sVirX2DId3sVvXCMxCvL
+          01Qj2HrqWBLZgNgfVMfLAdc6pzKgIBUj4ect+4LcL5+hQZlEKKP3HFF0cnRHkK0z
+          k1jpgj70DX9va3I3axnZdnP4c5QLbbLjYy4kX/MpmL9/veG+dlus3aeOBbfEQkM2
+          ihG+zQKBgQC8LAyUGl+flNy0gpy/IwPW0mGuqKd3bPpZuFBEanMaFWv1LyYbZTUq
+          W+LOaNTswEg9HVWNYO9Sb5koaJfapkEm+8wcWg8GgRgKLxblKkj89FcDLXfTnARH
+          RN281afqPHUrkglw0jYTvJNMCl1LJ5mgzmAeKhZgsbu85qVIdzLIOw==
+          -----END RSA PRIVATE KEY-----
+        ca: |-
+          -----BEGIN CERTIFICATE-----
+          MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT
+          MREwDwYDVQQIDAhWaXJnaW5pYTETMBEGA1UEBwwKQWxleGFuZHJpYTEkMCIGA1UE
+          CgwbRGVjaXBoZXIgVGVjaG5vbG9neSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVl
+          cmluZzEuMCwGA1UEAwwlRGVjaXBoZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChS
+          b290KTEqMCgGCSqGSIb3DQEJARYbZW5naW5lZXJpbmdAZGVjaXBoZXJub3cuY29t
+          MB4XDTE3MDgwOTExMjMwOFoXDTI3MDgwNzExMjMwOFowgcAxCzAJBgNVBAYTAlVT
+          MREwDwYDVQQIDAhWaXJnaW5pYTEkMCIGA1UECgwbRGVjaXBoZXIgVGVjaG5vbG9n
+          eSBTdHVkaW9zMRQwEgYDVQQLDAtFbmdpbmVlcmluZzE2MDQGA1UEAwwtRGVjaXBo
+          ZXIgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IChJbnRlcm1lZGlhdGUpMSowKAYJKoZI
+          hvcNAQkBFhtlbmdpbmVlcmluZ0BkZWNpcGhlcm5vdy5jb20wggIiMA0GCSqGSIb3
+          DQEBAQUAA4ICDwAwggIKAoICAQDPkxaiUD3uqR2AA5jwAb9gCjD+BrOrYBoelnR6
+          u29FPT5cHeM8bfVo6zixy7qC2lXzhK5gH/TLWXelpEwU+sw81oUbzZlB7Z2lvpj8
+          t4zXg4zgHNPqAFJM6L9b70dLgukhcUO6nnIiPPAprmtBDvXbtBwDCzOPaMcBeEwi
+          zERa4WyXYjn5Q+a8LTTLQ/OFmLHFA2dCG78s6cYQOfF92L641QdOhqXPtq+QwqAm
+          WkQ53Pes6rHmjT0kC8hEI5fCKEA3QXYt6YtgX+KIHgOYWI0g22wh95ohk+DuRL/O
+          3zzJ9tCjrMPO2lxmg0GdpuqjfR6K8CEk4Yq2dUwYC7dffgCrWv9zik/pXeoSvTv3
+          XprMN2WWKBX9lVC2qKFhNX4driBFRO0i5+bGdM1e8NilUDqHiikwhaVx2znb/E/b
+          LCCwlhC0oAAxnVZ1J18k46STe7hlg/RqM/18uxmhP9an2FkDtuyZBugbpWpgk7lE
+          tpOd92iCGYDc6k8Jsn+p0UiZjioJv/Gm04T3t90dkVu7D+mwFIsEAaJjwepEZ7ki
+          IBayWrJml+DT4ghyadkms8UaOa+YOYEZiY5GzJhEodAt01OanSkzR/FYjM4SuGXw
+          Rrq2p8hTuUBBm1p9ipv8DLqPmlXZ2Cn7ByTX7TMsG+77R4zkka5XD5tULpAf5xKo
+          qx4N/QIDAQABo2YwZDAdBgNVHQ4EFgQUbA2I9pZUJ7Z6WxXfTRecoCsqfnUwHwYD
+          VR0jBBgwFoAUY5U4Jb8hC6Ssinh2LzCB3tly8bcwEgYDVR0TAQH/BAgwBgEB/wIB
+          ADAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAHMtenslnEuvnT4g
+          JWR70FZv3wUOOqAsyxJdWj4o8yM7/V3wGKMxkRv7Oqetp92XYauffSPxE3INnGMq
+          DdRMTf2MGVnv/W5PJouZwMhBX4W6rjvl4QCSl+Q+wSt+OibNu2AxdCeQKa67cwvf
+          QfD4ufeWfvUPzazwzuJqE5WCjNnM2KsWbmzclquAbUjKH0017UGRYe8THrCZ5Mdn
+          L9X+ZSe5wWHWIm7JLn5nexeW668hgcdINrKBRg7ygKWrO/aMFnl3cQXmbNtXBt+y
+          E5tof618/HWJBjC3e+eyIMqjgjEZmxYfxwBTk0XVEZuA3PyAGigA17Q0ev5Zx4ii
+          2fGIYN5y3L6OMrfkcmdtihoQisqd+zKlgxWH4Z2KtV0RFVTreooNaSpFZu6EeCPH
+          0fg++TV/uGOEfNc4seEfFiaM4uq8mp5E1PYOXX4DLkzignqql9h8u3/3ZC7m4NoY
+          qpoOurQyY/dCUIJw3Kb+Dlck1OZsGQNvkpflHvCxCvTq48bEgjO+xkoYBODhY0wT
+          grl1kFBXMNNAiFiHlHaM6h+MKv/9cRi63KXmhiEjUWUVcdT9ZRRPJ6qd5QAJHJ+h
+          NU7s17ar5/4SgJx9BZSEYzQQCzt4REwBxfrF/GdGNia1wZcqMNylmkD8fCWBZiW2
+          sarsDzVzwvduL1ODIycXxe/pZUxi
+          -----END CERTIFICATE-----
+          -----BEGIN CERTIFICATE-----
+          MIIGgjCCBGqgAwIBAgIJAKBdlRUnXXIJMA0GCSqGSIb3DQEBCwUAMIHNMQswCQYD
+          VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
+          JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
+          RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
+          cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
+          bm93LmNvbTAeFw0xNzA4MDkxMTIyMTlaFw0yNzA4MDcxMTIyMTlaMIHNMQswCQYD
+          VQQGEwJVUzERMA8GA1UECAwIVmlyZ2luaWExEzARBgNVBAcMCkFsZXhhbmRyaWEx
+          JDAiBgNVBAoMG0RlY2lwaGVyIFRlY2hub2xvZ3kgU3R1ZGlvczEUMBIGA1UECwwL
+          RW5naW5lZXJpbmcxLjAsBgNVBAMMJURlY2lwaGVyIENlcnRpZmljYXRlIEF1dGhv
+          cml0eSAoUm9vdCkxKjAoBgkqhkiG9w0BCQEWG2VuZ2luZWVyaW5nQGRlY2lwaGVy
+          bm93LmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALDo08zRbssi
+          vrgIyCiE3x5ttHDcEsOs3EaZaE3hHpXK5an5iXT8/tl35BDAWl1J6CJkm4ip0Ch5
+          jOqrk5peQJKuN731GlafzoabwHcqyD6CvJZANre64s0J2CTZpob2gWM06C75uwzK
+          5W4JfivSzBpHu8A+FJARmZpnQoFDRIPWQFk9q22CPIWtlUdrkwVdnHlV++hRKKBU
+          qwAyXj6UUnrvwWNER0C0wksoJf+5oP/HLyqzUcd6yPmOiAe8QhR8jLdt/K8e14GI
+          7XhAytKxI2qHqzUmi2T57lIzz83fG4Cmo59mIF4jLvHfjC48zz9dCoObCK/QcczX
+          lipxmTm9HocDWCCo0L035arvWxRkP8ec75CE20Q8RqUY9jQo4a64RydbAabCw8s0
+          b0mSoHbRvpZCx96KhCG7EkjCorWrvh9dxZAenIZDAbn3sX9QGc6A+B5MYbv70UKo
+          8RD2IODsvuCSnn1rEQpGb0d6hNSReDN2cYLnSeuoMUlxT/SRCNBizGOWxJuFL1Cr
+          5YnNyUv3tCEXKxEM9OoRHutydmeg8fTbTu8hAlGiYhgqehmkApS25qCl4sVz3FUj
+          /y2yfQbecliu/YdPVziRGsLOTGhQldBSIaVdMGA/muzxVtOJdLBuK/qK/gvW7N2s
+          vZQTHZz+B10Dlxs9S2Nhf7FX7pMLM9hXAgMBAAGjYzBhMB0GA1UdDgQWBBRjlTgl
+          vyELpKyKeHYvMIHe2XLxtzAfBgNVHSMEGDAWgBRjlTglvyELpKyKeHYvMIHe2XLx
+          tzAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsF
+          AAOCAgEAcB4z4ALRX+s1Fb1j2sWLo65jIyxm0OB2RTlhstd4+zd+zFjLg7XE0O5j
+          Ilm3basVlLM2mTmi5CC4mvOBibSb6NlJr34GmKbfwYVLj3tpnlnA/HGGzHY3uoX6
+          zBUSIYRH10k2bmpM438fXtz9P+kHAkmsVj2Yk8uLg+tZDZEdM8qiWbaIZa+awHwL
+          DBhd1dQ7ZyejVJLKGyYwd7dMYLq04F4AqawPp2ksmcUtktU2Q+uGmJBkqgBzUTC+
+          64yPKBbPa2WFFDVtqt0r6qD2N7FD6v0b0PiBeruvhpSva1yvE0vMNfa9kc8ExrKz
+          7GMMGsv3TIOqK0tYXJayoM+8VAELwBcFvkCkobs4TtkF3VoPiO91hlm7K+7woNQH
+          OVhxqDqH3ECA7vNLeA09xT7EApXzPGwk163O4qoZdT7VUI2Fu9G0+IzzS42TVXOm
+          MUp1sEidUUElwuuqDvKxsBP6do9xT8dHg2n9Y04ME2FyQ1omuLzRrcyjU6Qo6PLr
+          H/di6KT3iiZ/leFkDMf5/Pesy7bExPZN2sHR3SpR5RwQh50T4KZx7FOqvCJpi6Pp
+          H1cz0921qGtG0iheOzWfonmvYKnhxcTTpg+fuiVdPWwdutjVl+HPc2yjw1Gdqw4h
+          n4oFjG4KQO6zvZzGDFay9HazZyUKpgamy24u8XY7/BSWc1c95Gg=
+          -----END CERTIFICATE-----
 gm-control-api:
   gmControlApi:
     ssl:
@@ -1810,7 +1959,6 @@ gm-control-api:
           P2kSkvCvEDfB7pBPac/ApkHFi6tsSLafbz1VVOfWLvweUqFnezu6zWD0qlP027U5
           zV4IjkhZcSD3x7rLHv63xsN0NU+/EZilO7VVa3RWro58+LJ/5SfOlK4=
           -----END RSA PRIVATE KEY-----
-
 
 control:
   control:

--- a/greymatter.yaml
+++ b/greymatter.yaml
@@ -9,6 +9,8 @@ global:
   mesh_tls:
     enabled: true
     use_provided_certs: true
+    # This i s the DN of the cert being used in the mesh.  The Helm charts will add whitelist the Dn throughout the mesh
+    dn: C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=*.greymatter.svc.cluster.local
   # Turns on tls for control api and configures control to talk to it using tls
   control_api_tls: true
   kafka:
@@ -29,6 +31,8 @@ global:
     port: 8500
   edge:
     enableTLS: true
+    # This is the DN of the new certificate issued to the edge for internal mesh communication. It needs to be whitelisted by the proxies
+    egressDn: C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=edge
     certPath: /etc/proxy/tls/edge
     version: 1.0.0
   spire:
@@ -77,7 +81,7 @@ global:
     controlApi:
       # This value must match global.control_api_tls
       egressTLS: true
-      
+
   sidecar:
     version: 1.0.0
     envvars:
@@ -468,10 +472,10 @@ catalog:
         value: 'world'
       client_identity:
         type: value
-        value: 'CN=gm-control,OU=Engineering,O=Decipher Technology Studios,=Alexandria,=Virginia,C=US'
+        value: 'C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=*.greymatter.svc.cluster.local'
       client_email:
         type: value
-        value: 'gm-control@deciphernow.com'
+        value: 'engineering@deciphernow.com'
 
     init:
       image: 'docker.production.deciphernow.com/deciphernow/gm-proxy:1.0.0'
@@ -645,6 +649,7 @@ internal-jwt:
         key: jwt.key.pem
 
     users_cg_name: internal-jwt-users
+    # This is a list of authorized users for the JWT service.  It's preloaded with the DNs for GM Control, Catalog and the Mesh Cert
     users: |-
       {
         "users": [
@@ -664,6 +669,20 @@ internal-jwt:
         },
         {
           "label": "CN=gm-catalog,OU=Engineering,O=Decipher Technology Studios,=Alexandria,=Virginia,C=US",
+          "values": {
+            "email": [
+                "engineering@deciphernow.com"
+            ],
+            "org": [
+                "www.deciphernow.com"
+            ],
+            "privilege": [
+                "root"
+            ]
+          }
+        },
+        {
+          "label": "C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=*.greymatter.svc.cluster.local",
           "values": {
             "email": [
                 "engineering@deciphernow.com"

--- a/greymatter/Chart.yaml
+++ b/greymatter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.1.0
 description: A Helm chart to deploy Grey Matter
 name: greymatter
-version: 2.1.1
+version: 2.1.2
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: edge
-    version: '2.1.1'
+    version: '2.1.2'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: jwt
@@ -35,7 +35,7 @@ dependencies:
 
   - name: gm-control-api
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
-    version: '2.1.3'
+    version: '2.1.4'
 
   - name: control
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'


### PR DESCRIPTION
## Details of the PR
Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

There are a lot of changes to this PR.  Specifically, it enables the `gm.impersonation` filter by default.  Full details of the bug can be found in the ticket below

Resolves #396 

## Yaml updates
2. What **changes to custom.yaml** are required?

This PR makes some significant changes to `greymatter.yaml` and to `greymatter-secrets.yaml`.  Anyone looking to use this version of Grey Matter will need to ensure they update any local references to these files, otherwise the mesh will not deploy correctly.

FYI - @danielpcox @tilleryd @kaitmore @dgoldstein1 

#### greymatter.yaml

* `.globals.mesh_tls.dn`
  * The mesh now needs to know the identity of the certificate being used in the mesh so that it can whitelist it
* `.globals.edge.egressDn`
  * This is the DN of the new certificate issued to the edge for internal mesh communication.  It needs to be whitelisted by the proxies
* `.catalog.catalog.envvars.client_identity`
  * Whether it's [a bug or not](https://github.com/DecipherNow/gm-catalog/issues/247), when impersonation is turned on, catalog does not use the `client_identity` environment variable.  Instead the impersonation uses the server certificate
* `.catalog.catalog.envvars.client_email`
  * For the same reasons above, we need to make sure the `client_email` is configured to the email associated with the mesh certificate from the jwt users.json file
* `.internal-jwt.jwt.users`
  * We now need to track the mesh certificate as an authorized jwt user

#### greymatter-secrets.yaml
There is a significant change to the `greymatter-secrets.yaml` file.  Now that the edge service has a specific cert for mesh communications, the chart has been updated to build both secrets.  You'll notice that there is now a map of certificates that will be ranged over by edge-secrets.yaml.  

Edge **ingress** represents the certificates presented to clients that attempt to gain access to the mesh from the external world

Edge **egress** represents the certificates that edge will use to talk to the mesh.  These certificates need to be issued from the same CA for certificates of the other sidecars, so they accept this certificate.

* `.edge.edge.certificates.ingress.{name,ca,key,cert}`
* `.edge.edge.certificates.egress.{name,ca,key,cert}`

## Configuration Changes
Have you documented any additional setup steps or configurations options?

There are no additional configuration steps required.

## Verification and Validation
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

#### Logs from Dashboard
```sh
Impersonation Successful -> USER_DN: CN=quickstart,OU=Engineering,O=Decipher Technology Studios,=Alexandria,=Virginia,C=US | EXTERNAL_SYS_DN:  | SSL_CLIENT_S_DN: C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=edge
Returning headers: USER_DN: CN=quickstart,OU=Engineering,O=Decipher Technology Studios,=Alexandria,=Virginia,C=US | EXTERNAL_SYS_DN: C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=edge | SSL_CLIENT_S_DN: C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=edge
```

#### Dashboard proxy configuration
```yaml
➜  ~ gm get proxy proxy-dashboard
[info] 2019/11/20 17:45:05 Preferring --api.key for authentication
{
  "proxy_key": "proxy-dashboard",
  "zone_key": "zone-default-zone",
  "name": "dashboard",
  "domain_keys": [
    "domain-dashboard"
  ],
  "listener_keys": [
    "listener-dashboard"
  ],
  "listeners": null,
  "active_proxy_filters": [
    "gm.impersonation",
    "gm.metrics"
  ],
  "proxy_filters": {
    "gm_impersonation": {
      "servers": "C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=edge|C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=*.greymatter.svc.cluster.local"
    },
    "gm_observables": {},
    "gm_oauth": {},
    "gm_inheaders": {},
    "gm_listauth": {},
    "gm_metrics": {
      "metrics_port": 8081,
      "metrics_host": "0.0.0.0",
      "metrics_dashboard_uri_path": "/metrics",
      "metrics_prometheus_uri_path": "/prometheus",
      "prometheus_system_metrics_interval_seconds": 15,
      "metrics_ring_buffer_size": 4096,
      "metrics_key_function": "depth",
      "metrics_key_depth": "1"
    },
    "envoy_rbac": null
  },
  "checksum": "9cee05ef4c79e34972795d9e9b20fbee996cea9cab9ba126f4df5e42c027c8bb"
}
```

#### Verification
```sh
➜  helm-charts git:(397_edge_cert) ✗ helm install greymatter -f greymatter.yaml -f greymatter-secrets.yaml --set global.environment=kubernetes
```

```sh
NAME                                    READY   STATUS      RESTARTS   AGE
catalog-5f7b84fcb6-pkbrh                2/2     Running     0          3m40s
catalog-init-phz8d                      0/1     Completed   3          3m40s
control-f8dd89f89-jz666                 1/1     Running     0          3m41s
dashboard-786cd9fddd-kntqq              2/2     Running     0          3m41s
data-0                                  2/2     Running     0          3m40s
data-internal-0                         2/2     Running     0          3m40s
data-mongo-0                            1/1     Running     0          3m40s
edge-668f5cb8b5-xcdx8                   1/1     Running     0          3m41s
gm-control-api-0                        2/2     Running     0          3m40s
gm-control-api-init-hlqdf               0/1     Completed   0          3m40s
internal-data-mongo-0                   1/1     Running     0          3m40s
internal-jwt-security-d46f458f6-hkwlw   2/2     Running     2          3m41s
internal-redis-56d95dc6b7-llbrg         1/1     Running     0          3m40s
jwt-security-78f77b8658-g9vr6           2/2     Running     3          3m41s
postgres-slo-0                          1/1     Running     0          3m40s
prometheus-5fd864c96f-4lh7x             2/2     Running     0          3m40s
redis-57c677dd7f-tjfc6                  1/1     Running     0          3m41s
slo-6447cb59cc-pjnbm                    2/2     Running     0          3m41s
voyager-edge-5c89cdfc8c-rjt4r           1/1     Running     0          3m35s
```

#### Screenshot
![image](https://user-images.githubusercontent.com/602099/69267294-d6830000-0b9a-11ea-9c64-c6ad6159de81.png)

