### PR TITLE
add gm-data securityContext supported by EKS

### DIFF
--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 2.1.3
+version: 2.1.4
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/data/templates/data.yaml
+++ b/data/templates/data.yaml
@@ -38,6 +38,12 @@ spec:
 {{ toYaml .Values.data.resources | indent 10 }}
         {{- end }}
         {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
+        {{- if .Values.data.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.data.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.data.securityContext.runAsGroup }}
+          fsGroup: {{ .Values.data.securityContext.fsGroup }}
+        {{- end }}
         securityContext:
           runAsUser: 666
           runAsGroup: 666

--- a/data/templates/data.yaml
+++ b/data/templates/data.yaml
@@ -15,6 +15,12 @@ spec:
       labels:
         app: {{ .Values.data.name }}
     spec:
+      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 1000
+        fsGroup: 2000
+      {{- end }}
       serviceAccountName: {{ .Values.global.waiter.serviceAccount.name }}
       initContainers:
         - name: ensure-{{ .Values.data.name }}

--- a/data/templates/data.yaml
+++ b/data/templates/data.yaml
@@ -15,12 +15,6 @@ spec:
       labels:
         app: {{ .Values.data.name }}
     spec:
-      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
-      securityContext:
-        runAsUser: 2000
-        runAsGroup: 1000
-        fsGroup: 2000
-      {{- end }}
       serviceAccountName: {{ .Values.global.waiter.serviceAccount.name }}
       initContainers:
         - name: ensure-{{ .Values.data.name }}
@@ -42,6 +36,12 @@ spec:
         {{- if .Values.data.resources }}
         resources:
 {{ toYaml .Values.data.resources | indent 10 }}
+        {{- end }}
+        {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
+        securityContext:
+          runAsUser: 666
+          runAsGroup: 666
+          fsGroup: 666
         {{- end }}
         env:
           {{- include "data.envvars" (dict "envvar" .Values.data.envvars "top" $) | indent 8 }}

--- a/data/values.yaml
+++ b/data/values.yaml
@@ -35,6 +35,7 @@ data:
   pvc:
     #size:
     mountPath: /app/buckets/{{ $.Values.data.aws.bucket}}/{{ $.Values.data.envvars.aws_s3_partition.value }}
+  # Allows operators to change the user and group to match the process running inside the gm-data container.
   securityContext:
     enabled: false
     runAsUser: 666

--- a/data/values.yaml
+++ b/data/values.yaml
@@ -35,6 +35,11 @@ data:
   pvc:
     #size:
     mountPath: /app/buckets/{{ $.Values.data.aws.bucket}}/{{ $.Values.data.envvars.aws_s3_partition.value }}
+  securityContext:
+    enabled: false
+    runAsUser: 666
+    runAsGroup: 666
+    fsGroup: 666
 
   # If Grey Matter Data is being deployed as a standalone instance, these values need to be provided
   deploy:

--- a/greymatter.yaml
+++ b/greymatter.yaml
@@ -157,6 +157,8 @@ data:
   data:
     image: docker.production.deciphernow.com/deciphernow/gm-data:1.0.0
     certs_mount_point: /app/certs
+    securityContext:
+      enabled: true
     envvars:
       uses3:
         type: value
@@ -305,13 +307,14 @@ internal-data:
         type: value
         value: 'data-internal'
   data:
-    image: docker.production.deciphernow.com/deciphernow/gm-data:1.0.0
-    certs_mount_point: /app/certs
     version: 1.0.0
     name: data-internal
+    image: docker.production.deciphernow.com/deciphernow/gm-data:1.0.0
+    certs_mount_point: /app/certs
+    securityContext:
+      enabled: true
     pvc:
       mountPath: /buckets/{{ $.Values.data.aws.bucket}}/{{ $.Values.data.envvars.aws_s3_partition.value }}
-
     envvars:
       gmdata_namespace:
         type: value

--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -4,12 +4,12 @@ dependencies:
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: data
-    version: '2.1.3'
+    version: '2.1.4'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
     alias: internal-data
     
   - name: data
-    version: '2.1.3'
+    version: '2.1.4'
     repository: 'https://nexus.production.deciphernow.com/repository/helm-hosted'
 
   - name: dashboard


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Added gm-data `securityContext` to support non-Openshift deployments. EKS for example, has stricter security policies that require the pod to use the same user/group as the container.

2. What **changes to custom.yaml** are required?

In greymatter.yaml, data securityContext is enabled by default, but I didn't add the user/group values, which can be found in data/templates/data.yaml.

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Deploy to EKS as well as Minikube, it should work on both. If you disable the securityContext then  the data container will not start in EKS.