### PR TITLE
WIP: only release new grey matter hosted charts on a tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,9 +152,9 @@ workflows:
       - package-and-publish-core-hosted:
           filters:
             tags:
-              ignore: /.*/
-            branches:
               only: /release-.*/
+            branches:
+              ignore: /.*/
       - package-and-publish-greymatter-hosted:
           requires:
             - package-and-publish-core-hosted

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ workflows:
       - package-and-publish-core-hosted:
           filters:
             tags:
-              only: /release-.*/
+              only: /.*/
             branches:
               ignore: /.*/
       - package-and-publish-greymatter-hosted:


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Currently our CI process builds a new Grey Matter hosted chart every time a PR is merged into the release branch.  This change will only build a hosted chart when a tag is applied.  This is the first step in revamping our CI process.

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

