### PR TITLE
info level logging for gm-control

### DIFF
--- a/greymatter.yaml
+++ b/greymatter.yaml
@@ -125,7 +125,7 @@ control:
     envvars:
       gm_control_console_level:
         type: 'value'
-        value: 'debug'
+        value: 'info'
       #gm_control_cmd:
       #  type: 'value'
       #  value: 'consul'


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Just needed to reduce the default logging level for gm-control.

2. What **changes to custom.yaml** are required?

See the one line change...

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Here's a bunch of log messages from control. Notice no DEBUG.

```
9:47PM INF Creating cluster for pod slo-684fd6b64f-fcjhn
9:47PM INF Adding named port proxy:8080 on pod "default.slo-684fd6b64f-fcjhn". To use a different named port, set --port-name.
9:47PM INF Adding pod "default.slo-684fd6b64f-fcjhn" (172.17.0.16:8080) in Cluster slo
9:47PM INF adding instance {172.17.0.16 8080 [{deployment slo} {pod-template-hash 684fd6b64f} {gm_k8s_host_ip 10.0.2.15} {gm_k8s_node_name minikube}]} to cluster  slo
9:47PM INF Creating cluster for pod voyager-edge-5c97445fc7-rfwvs
9:47PM INF Ignoring pod "default.voyager-edge-5c97445fc7-rfwvs", because it has no port named "proxy" (can be configured with --port-name).
9:47PM INF received update namespace=default
```
