### PR TITLE
disable gm-data security context by default

### DIFF
--- a/data/templates/data.yaml
+++ b/data/templates/data.yaml
@@ -15,9 +15,11 @@ spec:
       labels:
         app: {{ .Values.data.name }}
     spec:
+      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
       {{- if .Values.data.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.data.securityContext.fsGroup }}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ .Values.global.waiter.serviceAccount.name }}
       initContainers:

--- a/greymatter.yaml
+++ b/greymatter.yaml
@@ -162,7 +162,7 @@ data:
     image: docker.production.deciphernow.com/deciphernow/gm-data:1.0.0
     certs_mount_point: /app/certs
     securityContext:
-      enabled: true
+      enabled: false
     envvars:
       uses3:
         type: value


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Set gm-data security-context by

2. What **changes to custom.yaml** are required?

```
data:
   ...
    securityContext:
      enabled: false
```

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Test steps:

1. deploy to Minikube and ensure that the security context is created by running `kubectl get pod internal-data-0 -o describe`
1. deploy to Minishift and ensure that the security context is **not** created by running `kubectl get pod internal-data-0 -o describe`
