### PR TITLE
update gm chart to 2.1.5

### DIFF
--- a/greymatter/Chart.yaml
+++ b/greymatter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.1.0
 description: A Helm chart to deploy Grey Matter
 name: greymatter
-version: 2.1.4
+version: 2.1.5
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering


### PR DESCRIPTION
Only increments the Grey Matter chart version to 2.1.5.  This was missed in my prior PR.