### PR TITLE
Allows voyager version 11.0.1 to work with later k8s versions.

### DIFF
--- a/ci/scripts/install-voyager.sh
+++ b/ci/scripts/install-voyager.sh
@@ -11,5 +11,5 @@ helm template --name voyager-operator \
   --set apiserver.enableAdmissionWebhook=false \
   voyager-v11.0.1.tgz > manifest.yaml
 patch manifest.yaml voyager.patch
-kubectl apply -f manifest.yaml
+kubectl apply -f manifest.yaml --validate=false
 while [[ $(kubectl get pods -n kube-system -l app=voyager -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "waiting for pod" && sleep 10; done


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Voyager 11.0.1 only works with later k8s versions with the validate=false flag enabled. Using minikube 1.4 you will not need this but the latest minikube will deploy a k8s that needs this.

<br/><br/>

2. What **changes to custom.yaml** are required?

None

<br/><br/>

3. Have you documented any additional setup steps or configurations options?

NA

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Ran in minikube.

<br/><br/>
