### PR TITLE
remove data sidecar configs

### DIFF
--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 2.1.5
+version: 2.1.6
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/data/values.yaml
+++ b/data/values.yaml
@@ -285,21 +285,6 @@ sidecar:
     xds_cluster:
       type: value
       value: '{{ $.Values.data.name }}'
-    envoy_admin_log_path:
-      type: value
-      value: '/dev/stdout'
-    proxy_dynamic:
-      type: value
-      value: 'true'
-    xds_host:
-      type: value
-      value: 'control.default.svc.cluster.local'
-    xds_node_id:
-      type: value
-      value: 'default'
-    xds_port:
-      type: value
-      value: '50000'
 
   certs:
     secret_name: "sidecar-certs"

--- a/greymatter/Chart.yaml
+++ b/greymatter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.1.0
 description: A Helm chart to deploy Grey Matter
 name: greymatter
-version: 2.1.8
+version: 2.1.9
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -5,11 +5,11 @@ dependencies:
 
   - name: data
     repository: file://../data
-    version: '2.1.5'
+    version: '2.1.6'
 
   - name: data
     repository: file://../data
-    version: '2.1.5'
+    version: '2.1.6'
     alias: internal-data
 
   - name: dashboard


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

`data/values.yaml` was updated to include sidecar configs that override global sidecar configs. The xds_host env var was hard coded to `control.default.svc.cluster.local` which meant gm-data wouldn't connect to gm-control in a namespace other than `default`. I removed the configs because this aligns with how we're managing sidecar configs in all the other charts.

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

1. Deploy to a different namespace other than default
2. Ensure that `catalog -> data -> jwt` works.
