### PR TITLE
mongo.ssl.enabled fix

### DIFF
--- a/greymatter-secrets.yaml
+++ b/greymatter-secrets.yaml
@@ -20,7 +20,6 @@ data:
       admin_password: 'mongopassword'
     ssl:
       certificates:
-        - name: mongo-ssl-certs
           ca: |-
             -----BEGIN CERTIFICATE-----
             MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT
@@ -243,7 +242,6 @@ internal-data:
       admin_password: 'mongopassword'
     ssl:
       certificates:
-        - name: mongo-ssl-certs
           ca: |-
             -----BEGIN CERTIFICATE-----
             MIIGcTCCBFmgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgc0xCzAJBgNVBAYTAlVT


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

When data has mongo ssl enabled it will use the mongo certs in greymatter-secrets.yaml. Unfortunately the removed lines in this PR cause helm to error out. Removing them restores desired functionality. mongo.ssl.name is what is used to choose the cert name anyways not mongo.ssl.certificates.name which is what is being removed.

<br/><br/>

2. What **changes to custom.yaml** are required?

Two lines of greymatter-secret.yaml is removed that would need to be removed anyway if one were trying to deploy mongo with ssl.

<br/><br/>

3. Have you documented any additional setup steps or configurations options?

NA

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Tested in minikube / HmC.

<br/><br/>
