### PR TITLE
Liveness probe to ensure XDS HOST is set correctly

### DIFF
--- a/dashboard/templates/dashboard.yaml
+++ b/dashboard/templates/dashboard.yaml
@@ -70,6 +70,14 @@ spec:
         resources:
 {{ toYaml .Values.sidecar.resources | indent 10 }}
         {{- end }}
+        livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - curl localhost:8001/clusters | grep 'xds_cluster.*healthy'
+            initialDelaySeconds: 30
+            periodSeconds: 30
         ports:
         - name: proxy
           containerPort: 8080

--- a/data/templates/data.yaml
+++ b/data/templates/data.yaml
@@ -110,6 +110,14 @@ spec:
               - "curl -k --cacert /etc/proxy/tls/sidecar/ca.crt --key /etc/proxy/tls/sidecar/server.key --cert /etc/proxy/tls/sidecar/server.crt https://localhost:8181/list/1/"
           initialDelaySeconds: 20
           periodSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - curl localhost:8001/clusters | grep 'xds_cluster.*healthy'
+          initialDelaySeconds: 10
+          periodSeconds: 10
 
       imagePullSecrets:
       - name: {{ .Values.data.imagePullSecret | default "docker.secret" }}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This implements the liveness probe that justincely prototyped out to check that XDS_HOST is correctly set. This probe is on dashboard to make sure that the globals are correct (would be really hard to mess up) and also on data in case it is deployed standalone.

<br/><br/>

2. What **changes to custom.yaml** are required?

None

<br/><br/>

3. Have you documented any additional setup steps or configurations options?

NA
<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Ran in minikube. Checked with using both the correct and wrong namespace for XDS_HOST.
<br/><br/>
