### PR TITLE
allows for the situation where the sidecar secret is already installed in the namespace

### DIFF
--- a/greymatter/templates/sidecar-secret.yaml
+++ b/greymatter/templates/sidecar-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.sidecar.create_sidecar_secret) (.Values.global.mesh_tls.use_provided_certs) }}
+{{- if .Values.sidecar.create_sidecar_secret }}
 {{- if .Values.sidecar.certificates }}
 {{- with .Values.sidecar.certificates }}
 ---


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR is in response to [this issue](https://github.com/DecipherNow/helm-charts/issues/488).  What was happening was that both `create_sidecar_secret` _and_ `mesh_tls.use_provided_certs` had to be false or else the sidecar secret would be created.  I removed the `mesh_tls.use_provided_certs` from the logic--I'm not sure why it was put there in the first place but I think it makes more sense without it.

<br/><br/>

2. What **changes to custom.yaml** are required?

n/a
<br/><br/>

3. Have you documented any additional setup steps or configurations options?

n/a
<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Ran in minikube.  I applied the sidecar secret manually first, then I helm installed greymatter with `create_sidecar_secret` set to false.
<br/><br/>
