### PR TITLE
Adds the missing spaces in the global zone templating

### DIFF
--- a/gm-control-api/Chart.yaml
+++ b/gm-control-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 1.1.0
 description: Deploys the Grey Matter 2.0 gm-control-api mesh-wide configuration API
 name: gm-control-api
-version: 2.1.6
+version: 2.1.7

--- a/gm-control-api/json/edge/cluster.json
+++ b/gm-control-api/json/edge/cluster.json
@@ -1,5 +1,5 @@
 {
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "cluster_key": "edge-to-{{.service.serviceName}}-cluster",
   "name": "{{.service.serviceName}}",
   "instances": [],

--- a/gm-control-api/json/edge/route-1.json
+++ b/gm-control-api/json/edge/route-1.json
@@ -1,7 +1,7 @@
 {
   "route_key": "edge-{{.service.serviceName}}-route",
   "domain_key": "edge",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "/services/{{.service.serviceName}}/latest/",
   "prefix_rewrite": "/",
   "redirects": null,

--- a/gm-control-api/json/edge/route-2.json
+++ b/gm-control-api/json/edge/route-2.json
@@ -1,7 +1,7 @@
 {
   "route_key": "edge-{{.service.serviceName}}-route-slash",
   "domain_key": "edge",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "/services/{{.service.serviceName}}/latest",
   "prefix_rewrite": "/services/{{.service.serviceName}}/latest/",
   "redirects": null,

--- a/gm-control-api/json/edge/shared_rules.json
+++ b/gm-control-api/json/edge/shared_rules.json
@@ -1,5 +1,5 @@
 {
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "shared_rules_key": "edge-{{.service.serviceName}}-shared-rules",
   "name": "{{.service.serviceName}}",
   "default": {

--- a/gm-control-api/json/services/cluster.json
+++ b/gm-control-api/json/services/cluster.json
@@ -1,6 +1,6 @@
 {
   "cluster_key": "cluster-{{.service.serviceName}}",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "name": "service",
   "instances": [
     {

--- a/gm-control-api/json/services/domain.json
+++ b/gm-control-api/json/services/domain.json
@@ -1,6 +1,6 @@
 {
   "domain_key": "domain-{{.service.serviceName}}",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "name": "*",
   "port": 8080,
   "redirects": null,

--- a/gm-control-api/json/services/listener.json
+++ b/gm-control-api/json/services/listener.json
@@ -1,6 +1,6 @@
 {
   "listener_key": "listener-{{.service.serviceName}}",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "name": "{{.service.serviceName}}",
   "ip": "0.0.0.0",
   "port": 8080,

--- a/gm-control-api/json/services/proxy.json
+++ b/gm-control-api/json/services/proxy.json
@@ -1,6 +1,6 @@
 {
   "proxy_key": "proxy-{{.service.serviceName}}",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "name": "{{.service.serviceName}}",
   "domain_keys": [
     "domain-{{.service.serviceName}}"

--- a/gm-control-api/json/services/route.json
+++ b/gm-control-api/json/services/route.json
@@ -1,7 +1,7 @@
 {
   "route_key": "route-{{.service.serviceName}}",
   "domain_key": "domain-{{.service.serviceName}}",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "/",
   "prefix_rewrite": null,
   "redirects": null,

--- a/gm-control-api/json/services/shared_rules.json
+++ b/gm-control-api/json/services/shared_rules.json
@@ -1,7 +1,7 @@
 {
   "shared_rules_key": "shared-rules-{{.service.serviceName}}",
   "name": "{{.service.serviceName}}",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "default": {
     "light": [
       {

--- a/gm-control-api/json/special/cluster.json
+++ b/gm-control-api/json/special/cluster.json
@@ -1,6 +1,6 @@
 {
     "cluster_key": "cluster-edge",
-    "zone_key": "{{.Values.global.zone}}",
+    "zone_key": "{{ .Values.global.zone }}",
     "name": "edge",
     "instances": [
       {

--- a/gm-control-api/json/special/domain.json
+++ b/gm-control-api/json/special/domain.json
@@ -1,6 +1,6 @@
 {
     "domain_key": "edge",
-    "zone_key": "{{.Values.global.zone}}",
+    "zone_key": "{{ .Values.global.zone }}",
     "name": "*",
     "port": 8080,
     "redirects": null,

--- a/gm-control-api/json/special/listener.json
+++ b/gm-control-api/json/special/listener.json
@@ -1,5 +1,5 @@
 {
-    "zone_key": "{{.Values.global.zone}}",
+    "zone_key": "{{ .Values.global.zone }}",
     "listener_key": "edge-listener",
     "domain_keys": ["edge"],
     "name": "edge",

--- a/gm-control-api/json/special/proxy.json
+++ b/gm-control-api/json/special/proxy.json
@@ -1,5 +1,5 @@
 {
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "proxy_key": "edge-proxy",
   "domain_keys": ["edge"],
   "listener_keys": ["edge-listener"],

--- a/gm-control-api/json/special/route-catalog-to-internal-data-slash.json
+++ b/gm-control-api/json/special/route-catalog-to-internal-data-slash.json
@@ -1,7 +1,7 @@
 {
   "route_key": "catalog-internal-data-route-slash",
   "domain_key": "domain-catalog",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "{{ .Values.global.catalog.data_prefix }}",
   "prefix_rewrite": "{{ .Values.global.catalog.data_prefix }}/",
   "redirects": null,

--- a/gm-control-api/json/special/route-catalog-to-internal-data.json
+++ b/gm-control-api/json/special/route-catalog-to-internal-data.json
@@ -1,7 +1,7 @@
 {
   "route_key": "catalog-internal-data-route",
   "domain_key": "domain-catalog",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "{{ .Values.global.catalog.data_prefix }}/",
   "prefix_rewrite": "/",
   "redirects": null,

--- a/gm-control-api/json/special/route-dashboard-slash.json
+++ b/gm-control-api/json/special/route-dashboard-slash.json
@@ -1,7 +1,7 @@
 {
   "route_key": "edge-dashboard-route-no-slash",
   "domain_key": "edge",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "/",
   "prefix_rewrite": null,
   "redirects": null,

--- a/gm-control-api/json/special/route-data-jwt-slash.json
+++ b/gm-control-api/json/special/route-data-jwt-slash.json
@@ -1,7 +1,7 @@
 {
   "route_key": "data-jwt-route-slash",
   "domain_key": "domain-data",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "{{ .Values.global.data.jwt_prefix }}",
   "prefix_rewrite": "{{ .Values.global.data.jwt_prefix }}/",
   "redirects": null,

--- a/gm-control-api/json/special/route-data-jwt.json
+++ b/gm-control-api/json/special/route-data-jwt.json
@@ -1,7 +1,7 @@
 {
   "route_key": "data-jwt-route",
   "domain_key": "domain-data",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "{{ .Values.global.data.jwt_prefix }}/",
   "prefix_rewrite": "/",
   "redirects": null,

--- a/gm-control-api/json/special/route-internal-data-jwt-slash.json
+++ b/gm-control-api/json/special/route-internal-data-jwt-slash.json
@@ -1,7 +1,7 @@
 {
   "route_key": "data-internal-jwt-route-slash",
   "domain_key": "domain-data-internal",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "{{ .Values.global.data.jwt_prefix }}",
   "prefix_rewrite": "{{ .Values.global.data.jwt_prefix }}/",
   "redirects": null,

--- a/gm-control-api/json/special/route-internal-data-jwt.json
+++ b/gm-control-api/json/special/route-internal-data-jwt.json
@@ -1,7 +1,7 @@
 {
   "route_key": "data-internal-jwt-route",
   "domain_key": "domain-data-internal",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "{{ .Values.global.data.jwt_prefix }}/",
   "prefix_rewrite": "/",
   "redirects": null,

--- a/gm-control-api/json/special/route.json
+++ b/gm-control-api/json/special/route.json
@@ -1,7 +1,7 @@
 {
   "route_key": "route-edge",
   "domain_key": "edge",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "path": "/services/edge/latest/",
   "prefix_rewrite": null,
   "redirects": null,

--- a/gm-control-api/json/special/shared_rules.json
+++ b/gm-control-api/json/special/shared_rules.json
@@ -1,7 +1,7 @@
 {
   "shared_rules_key": "shared-rules-edge",
   "name": "edge",
-  "zone_key": "{{.Values.global.zone}}",
+  "zone_key": "{{ .Values.global.zone }}",
   "default": {
     "light": [
       {

--- a/greymatter/Chart.yaml
+++ b/greymatter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.1.0
 description: A Helm chart to deploy Grey Matter
 name: greymatter
-version: 2.1.14
+version: 2.1.15
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   - name: gm-control-api
     repository: file://../gm-control-api
-    version: '2.1.6'
+    version: '2.1.7'
 
   - name: control
     repository: file://../control


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR fixes #514 and allows Helm to once again properly template the global zones for all of the mesh configurations.

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

none

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

I caught the error attempting to deploy in [k3d](https://github.com/rancher/k3d).

The original error:

```json
{"level":"error","service":"gm-control-api","handler":"/v1.0/zone/{{+.Values.global.zone+}}","method":"GET","headers":"(Accept-Encoding, gzip), (User-Agent, Go-http-client/1.1), (Authorization, xxx), (X-Gm-Api-Client-App, github.com/deciphernow/gm-control), (X-Gm-Api-Client-Type, github.com/deciphernow/gm-control-api/api/client), (X-Gm-Api-Client-Version, v1.1.0)","Zone().Get":"Not found","Key":"{{+.Values.global.zone+}}","method":"GET","code":400,"time":"2020-03-17T19:16:05Z","message":"Index"}
```

After updating the charts locally and redeploying

```json
{"level":"debug","service":"gm-control-api","handler":"/v1.0/cluster/edge-to-slo-cluster","method":"PUT","headers":"(X-Gm-Api-Client-Type, github.com/deciphernow/gm-control-api/api/client), (X-Gm-Api-Client-Version, v1.1.0), (Accept-Encoding, gzip), (User-Agent, Go-http-client/1.1), (Content-Length, 704), (Authorization, xxx), (X-Gm-Api-Client-App, github.com/deciphernow/gm-control)","cluster":"{ClusterKey:edge-to-slo-cluster ZoneKey:zone-default-zone Name:slo RequireTLS:true Secret:{SecretKey: Name: ValidationName: Subjects:[] ECDHCurves:[] ForwardClientCertDetails: SetCurrentClientCertDetails:{URI:false} Checksum:{Checksum:}} SSLConfig:0xc000062d80 Instances:[] OrgKey: CircuitBreakersThresholds:<nil> OutlierDetection:<nil> HealthChecks:[] Checksum:{Checksum:335c4e3e0465d0a0c7f6747b5ecb7f875ddd9f52d0f89ab173bc9a6624fda5ad}}","time":"2020-03-17T19:36:09Z","message":"handleV1ClusterPUT"}
```

![image](https://user-images.githubusercontent.com/602099/76896595-824a0d00-6868-11ea-8752-aee33fef4462.png)

