### PR TITLE
add observables configurable by values

### DIFF
--- a/gm-control-api/json/special/proxy.json
+++ b/gm-control-api/json/special/proxy.json
@@ -5,8 +5,22 @@
   "listener_keys": ["edge-listener"],
   "name": "edge",
   "listeners": null,
-  "active_proxy_filters": ["gm.metrics", "gm.inheaders"],
+  "active_proxy_filters": [
+    {{- if .Values.global.services.edge.observablesEnabled }}
+    "gm.observables",
+  {{- end }}
+    "gm.metrics",
+    "gm.inheaders"
+  ],
   "proxy_filters": {
+    {{-  if .Values.global.services.edge.observablesEnabled }}
+    "gm_observables": {
+      "useKafka": true,
+      "topic": "{{ .Values.global.services.edge.serviceName }}",
+      "eventTopic": "{{ .Values.global.observables.topic }}",
+      "kafkaServerConnection": "{{ .Values.global.observables.kafkaServerConnection }}"
+    },
+    {{- end }}
     "gm_metrics": {
       "metrics_port": 8081,
       "metrics_host": "0.0.0.0",


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This allows observables to be set up in a similar way they are in all other service mesh configs.

Start greymatter with:
`helm install greymatter --name gm-deploy -f greymatter.yaml -f greymatter-secrets.yaml -f credentials.yaml --set global.services.edge.observablesEnabled=true --set global.environment=kubernetes`

2. What **changes to custom.yaml** are required?

None

3. Have you documented any additional setup steps or configurations options?

None

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

run `kc get configmap special-mesh-config -o yaml` and scroll down to `proxy.json:` when `--set global.services.edge.observablesEnabled=true` gm.observables is added to active filters and gm_observables filter is added to proxy_filters

```
apiVersion: v1
data:
  cluster.json: |-
    {
        "cluster_key": "cluster-edge",
        "zone_key": "zone-default-zone",
        "name": "edge",
        "instances": [
          {
              "host": "localhost",
              "port": 8080
          }
        ],
        "circuit_breakers": null,
        "outlier_detection": null,
        "health_checks": []
      }
  domain.json: |-
    {
        "domain_key": "edge",
        "zone_key": "zone-default-zone",
        "name": "*",
        "port": 8080,
        "redirects": null,
        "gzip_enabled": false,
        "cors_config": null,
        "aliases": null,
        "force_https": true,
        "ssl_config": {
            "protocols": ["SSLv3", "SSLv2", "TLSv1", "TLSv1.1", "TLSv1.2"],
            "require_client_certs": true,
            "trust_file": "/etc/proxy/tls/edge/ca.crt",
            "cert_key_pairs": [
                {
                    "certificate_path": "/etc/proxy/tls/edge/server.crt",
                    "key_path": "/etc/proxy/tls/edge/server.key"
                }
            ]
        }
    }
  listener.json: |-
    {
        "zone_key": "zone-default-zone",
        "listener_key": "edge-listener",
        "domain_keys": ["edge"],
        "name": "edge",
        "ip": "0.0.0.0",
        "port": 8080,
        "protocol": "http_auto",
        "tracing_config": null
    }
  proxy.json: |-
    {
      "zone_key": "zone-default-zone",
      "proxy_key": "edge-proxy",
      "domain_keys": ["edge"],
      "listener_keys": ["edge-listener"],
      "name": "edge",
      "listeners": null,
      "active_proxy_filters": [
        "gm.observables",
        "gm.metrics",
        "gm.inheaders"
      ],
      "proxy_filters": {
        "gm_observables": {
          "useKafka": true,
          "topic": "Grey Matter Edge",
          "eventTopic": "observables",
          "kafkaServerConnection": ""
        },
        "gm_metrics": {
          "metrics_port": 8081,
          "metrics_host": "0.0.0.0",
          "metrics_dashboard_uri_path": "/metrics",
          "metrics_prometheus_uri_path": "/prometheus",
          "metrics_ring_buffer_size": 4096,
          "prometheus_system_metrics_interval_seconds": 15,
          "metrics_key_function": "none"
        }
      }
    }
  route-catalog-to-internal-data-slash.json: |-
    {
      "route_key": "catalog-internal-data-route-slash",
      "domain_key": "domain-catalog",
      "zone_key": "zone-default-zone",
      "path": "/data",
      "prefix_rewrite": "/data/",
      "redirects": null,
      "shared_rules_key": "edge-data-internal-shared-rules",
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "retry_policy": null
    }
  route-catalog-to-internal-data.json: |-
    {
      "route_key": "catalog-internal-data-route",
      "domain_key": "domain-catalog",
      "zone_key": "zone-default-zone",
      "path": "/data/",
      "prefix_rewrite": "/",
      "redirects": null,
      "shared_rules_key": "edge-data-internal-shared-rules",
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "retry_policy": null
    }
  route-dashboard-slash.json: |-
    {
      "route_key": "edge-dashboard-route-no-slash",
      "domain_key": "edge",
      "zone_key": "zone-default-zone",
      "path": "/",
      "prefix_rewrite": null,
      "redirects": null,
      "shared_rules_key": "edge-dashboard-shared-rules",
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "retry_policy": null
    }
  route-data-jwt-slash.json: |-
    {
      "route_key": "data-jwt-route-slash",
      "domain_key": "domain-data",
      "zone_key": "zone-default-zone",
      "path": "/jwt",
      "prefix_rewrite": "/jwt/",
      "redirects": null,
      "shared_rules_key": "edge-jwt-security-shared-rules",
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "retry_policy": null
    }
  route-data-jwt.json: |-
    {
      "route_key": "data-jwt-route",
      "domain_key": "domain-data",
      "zone_key": "zone-default-zone",
      "path": "/jwt/",
      "prefix_rewrite": "/",
      "redirects": null,
      "shared_rules_key": "edge-jwt-security-shared-rules",
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "retry_policy": null
    }
  route-internal-data-jwt-slash.json: |-
    {
      "route_key": "data-internal-jwt-route-slash",
      "domain_key": "domain-data-internal",
      "zone_key": "zone-default-zone",
      "path": "/jwt",
      "prefix_rewrite": "/jwt/",
      "redirects": null,
      "shared_rules_key": "edge-internal-jwt-security-shared-rules",
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "retry_policy": null
    }
  route-internal-data-jwt.json: |-
    {
      "route_key": "data-internal-jwt-route",
      "domain_key": "domain-data-internal",
      "zone_key": "zone-default-zone",
      "path": "/jwt/",
      "prefix_rewrite": "/",
      "redirects": null,
      "shared_rules_key": "edge-internal-jwt-security-shared-rules",
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "retry_policy": null
    }
  route.json: |-
    {
      "route_key": "route-edge",
      "domain_key": "edge",
      "zone_key": "zone-default-zone",
      "path": "/services/edge/latest/",
      "prefix_rewrite": null,
      "redirects": null,
      "shared_rules_key": "shared-rules-edge",
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "retry_policy": null
    }
  shared_rules.json: |-
    {
      "shared_rules_key": "shared-rules-edge",
      "name": "edge",
      "zone_key": "zone-default-zone",
      "default": {
        "light": [
          {
            "constraint_key": "",
            "cluster_key": "cluster-edge",
            "metadata": null,
            "properties": null,
            "response_data": {},
            "weight": 1
          }
        ],
        "dark": null,
        "tap": null
      },
      "rules": null,
      "response_data": {},
      "cohort_seed": null,
      "properties": null,
      "retry_policy": null
    }
kind: ConfigMap
metadata:
  creationTimestamp: "2020-03-19T20:20:59Z"
  name: special-mesh-config
  namespace: default
  resourceVersion: "36053"
  selfLink: /api/v1/namespaces/default/configmaps/special-mesh-config
  uid: 657494ad-0ef4-4735-a031-44cadf6ffae0
```
