### PR TITLE
add in spire makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,14 @@ destroy:
 # Grey Matter Specific targets
 # To target individual sub charts you can go the directory and use the make targets there.
 
-clean: 
+clean:
+	(cd spire && make clean-spire)
 	(cd fabric && make clean-fabric)
 	(cd data && make clean-data)
 	(cd sense && make clean-sense)
 
 dev-dep: clean
+	(cd spire && make package-spire)
 	(cd fabric && make package-fabric)
 	(cd data && make package-data)
 	(cd sense && make package-sense)
@@ -49,6 +51,7 @@ check-secrets:
 
 .PHONY: install
 install: dev-dep check-secrets
+	(cd spire && make spire)
 	(cd fabric && make fabric)
 	(cd edge && make edge)
 	(cd data && make data)
@@ -58,6 +61,7 @@ install: dev-dep check-secrets
 .IGNORE: uninstall
 .PHONY: uninstall
 uninstall:
+	-(cd spire && make remove-spire)
 	-(cd fabric && make remove-fabric)
 	-(cd edge && make remove-edge)
 	-(cd data && make remove-data)
@@ -78,6 +82,7 @@ OUTPUT_PATH=./logs
 template: dev-dep $(BUILD_NUMBER_FILE)
 	@echo "Templating the greymatter helm charts"
 	mkdir -p $(OUTPUT_PATH)
+	(cd spire && make template-spire && cp $(OUTPUT_PATH)/* ../$(OUTPUT_PATH)/)
 	(cd fabric && make template-fabric && cp $(OUTPUT_PATH)/* ../$(OUTPUT_PATH)/)
 	(cd edge && make template-edge && cp $(OUTPUT_PATH)/* ../$(OUTPUT_PATH)/)
 	(cd data && make template-data && cp $(OUTPUT_PATH)/* ../$(OUTPUT_PATH)/)

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,11 @@ check-secrets:
 install: dev-dep check-secrets
 	(cd spire && make spire)
 	(cd fabric && make fabric)
+	sleep 20
 	(cd edge && make edge)
+	sleep 20
 	(cd data && make data)
+	sleep 20
 	(cd sense && make sense)
 	(make reveal-endpoint)
 

--- a/data/Makefile
+++ b/data/Makefile
@@ -10,15 +10,15 @@ wsa-data:
 
 .PHONY: gm-data
 gm-data: wsa-data
-	helm install $(NAME-DATA) gm-data --set=global.environment=kubernetes $(WAITERSACHECK-DATA)
+	helm install $(NAME-DATA) gm-data --set=global.environment=kubernetes $(WAITERSACHECK-DATA) -f ../global.yaml
 
 .PHONY: jwt
 jwt: wsa-data
-	helm install jwt-$(NAME-DATA) jwt --set=global.environment=kubernetes $(WAITERSACHECK-DATA)
+	helm install jwt-$(NAME-DATA) jwt --set=global.environment=kubernetes $(WAITERSACHECK-DATA) -f ../global.yaml
 
 .PHONY: jwt-gov
 jwt-gov: wsa-data
-	helm install $(NAME-DATA) jwt-gov --set=global.environment=kubernetes $(WAITERSACHECK-DATA)
+	helm install $(NAME-DATA) jwt-gov --set=global.environment=kubernetes $(WAITERSACHECK-DATA) -f ../global.yaml
 
 clean-data:
 	rm -f ./charts/*
@@ -33,7 +33,7 @@ template-data: package-data $(BUILD_NUMBER_FILE)
 
 .PHONY: data
 data: package-data wsa-data
-	helm install $(NAME-DATA) . --set=global.environment=kubernetes $(WAITERSACHECK-DATA)
+	helm install $(NAME-DATA) . --set=global.environment=kubernetes $(WAITERSACHECK-DATA) -f ../global.yaml
 
 .PHONY: remove-data
 remove-data:

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -10,10 +10,10 @@ include ../output.mk
 edge:
 	if [ "$(pwd_name)" == "edge" ]; then \
 		echo "run in makefile directory"; \
-		helm install edge . --set=global.environment=kubernetes; \
+		helm install edge . --set=global.environment=kubernetes -f ../global.yaml; \
 	else \
 		echo "run in helm-charts top directory"; \
-		helm install edge edge --set=global.environment=kubernetes; \
+		helm install edge edge --set=global.environment=kubernetes -f ../global.yaml; \
 	fi
 
 .PHONY: remove-edge

--- a/global.yaml
+++ b/global.yaml
@@ -1,0 +1,26 @@
+global:
+  # Used as imagePullSecrets value for each subchart
+  image_pull_secret: docker.secret    
+  # Deployment environment, one of "eks", "kuberenetes", or "openshift"
+  environment: kubernetes
+  # Used to configure control and control-api environment variables
+  zone: zone-default-zone
+  # Whether to use consul for service discovery
+  consul:       
+    enabled: false
+    host: ''
+    port: 8500
+  # Port for Grey Matter Control. Used in catalog init and sidecar envvars.
+  control_port: 50000
+  # Whether or not to use spire for cert management and the trust domain
+  spire:
+    enabled: true
+    trust_domain: quickstart.greymatter.io
+  # Configures the init container used to wait on various deployments to be ready
+  waiter:                             
+    image: deciphernow/k8s-waiter:latest
+    service_account:
+      name: waiter-sa
+  # Global sidecar config (supports version and envvars)
+  sidecar:
+    version: 1.2.2

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -10,15 +10,15 @@ wsa-sense:
 
 .PHONY: catalog
 catalog: wsa-sense
-	helm install $(NAME-SENSE) catalog --set=global.environment=kubernetes $(WAITERSACHECK-SENSE)
+	helm install $(NAME-SENSE) catalog --set=global.environment=kubernetes $(WAITERSACHECK-SENSE) -f ../global.yaml
 
 .PHONY: dashboard
 dashboard: wsa-sense
-	helm install $(NAME-SENSE) dashboard --set=global.environment=kubernetes $(WAITERSACHECK-SENSE)
+	helm install $(NAME-SENSE) dashboard --set=global.environment=kubernetes $(WAITERSACHECK-SENSE) -f ../global.yaml
 
 .PHONY: slo
 slo: wsa-sense
-	helm install $(NAME-SENSE) slo --set=global.environment=kubernetes $(WAITERSACHECK-SENSE)
+	helm install $(NAME-SENSE) slo --set=global.environment=kubernetes $(WAITERSACHECK-SENSE) -f ../global.yaml
 
 clean-sense:
 	rm -f ./charts/*
@@ -33,7 +33,7 @@ template-sense: package-sense $(BUILD_NUMBER_FILE)
 
 .PHONY: sense
 sense: package-sense wsa-sense
-	helm install $(NAME-SENSE) . --set=global.environment=kubernetes $(WAITERSACHECK-SENSE)
+	helm install $(NAME-SENSE) . --set=global.environment=kubernetes $(WAITERSACHECK-SENSE) -f ../global.yaml
 
 .PHONY: remove-sense
 remove-sense:

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -1,0 +1,36 @@
+SHELL := /bin/bash
+NAME-SPIRE:=spire
+CHART-SPIRE := .
+
+include ../output.mk
+
+wsa-spire:
+	$(eval WAITERSACHECK-SPIRE=$(shell kubectl get sa waiter-sa | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
+	echo $(WAITERSACHECK-SPIRE)
+
+.PHONY: server
+server: wsa-spire
+	helm install $(NAME-SPIRE)-server server --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE)
+
+.PHONY: agent
+agent: wsa-spire
+	helm install $(NAME-SPIRE)-agent agent --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE)
+
+clean-spire:
+	rm -f ./charts/*
+
+package-spire: clean-spire
+	echo "target hit package-spire"
+	helm dep up .
+
+template-spire: package-spire $(BUILD_NUMBER_FILE)
+	mkdir -p $(OUTPUT_PATH)
+	helm template $(NAME-SPIRE) . --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE) > $(OUTPUT_PATH)/helm-$(NAME-SPIRE)$(BN).yaml
+
+.PHONY: spire
+spire: package-spire wsa-spire
+	helm install $(NAME-SPIRE) . --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE)
+
+.PHONY: remove-spire
+remove-spire:
+	helm uninstall $(shell helm ls | grep spire | awk '{print $$1}')

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -10,11 +10,11 @@ wsa-spire:
 
 .PHONY: server
 server: wsa-spire
-	helm install $(NAME-SPIRE)-server server --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE)
+	helm install $(NAME-SPIRE)-server server --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE) -f ../global.yaml
 
 .PHONY: agent
 agent: wsa-spire
-	helm install $(NAME-SPIRE)-agent agent --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE)
+	helm install $(NAME-SPIRE)-agent agent --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE) -f ../global.yaml
 
 clean-spire:
 	rm -f ./charts/*

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -29,7 +29,7 @@ template-spire: package-spire $(BUILD_NUMBER_FILE)
 
 .PHONY: spire
 spire: package-spire wsa-spire
-	helm install $(NAME-SPIRE) . --set=global.environment=kubernetes $(WAITERSACHECK-SPIRE)
+	(make server && sleep 20 && make agent)
 
 .PHONY: remove-spire
 remove-spire:

--- a/spire/README.md
+++ b/spire/README.md
@@ -13,3 +13,15 @@ minikube start -p gm-deploy --memory 26384 --cpus 6 \
     --extra-config=apiserver.authorization-mode=Node,RBAC \
     --extra-config=kubelet.authentication-token-webhook=true
 ```
+
+## Makefile
+
+| command        | description                         | comments |
+| -------------- | ----------------------------------- | -------- |
+| server         | install standalone spire server     |          |
+| agent          | install standalone spire agent      |          |
+| clean-spire    | remove charts/*                     |          |
+| package-spire  | package spire                       |          |
+| template-spire | template spire with values          |          |
+| spire          | package and install spire component |          |
+| remove-spire   | uninstalls spire component          |          |


### PR DESCRIPTION
This PR adds a makefile for spire helm releases and updates the top level Makefile to install spire with the rest of the Grey Matter core components.

To test you can start up a k3d cluster and then run `make install` 