### PR TITLE
Pushing timeout back for devinabox openshift

### DIFF
--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 2.1.9
+version: 2.1.10
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/data/templates/data.yaml
+++ b/data/templates/data.yaml
@@ -116,7 +116,7 @@ spec:
             - /bin/sh
             - -c
             - curl localhost:8001/clusters | grep 'xds_cluster.*healthy'
-          initialDelaySeconds: 10
+          initialDelaySeconds: 30
           periodSeconds: 10
 
       imagePullSecrets:

--- a/greymatter/Chart.yaml
+++ b/greymatter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.1.0
 description: A Helm chart to deploy Grey Matter
 name: greymatter
-version: 2.1.15
+version: 2.1.16
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/greymatter/requirements.yaml
+++ b/greymatter/requirements.yaml
@@ -5,11 +5,11 @@ dependencies:
 
   - name: data
     repository: file://../data
-    version: '2.1.9'
+    version: '2.1.10'
 
   - name: data
     repository: file://../data
-    version: '2.1.9'
+    version: '2.1.10'
     alias: internal-data
 
   - name: dashboard


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Sets the timeout further into the future for data's liveness probe. Needed because openshift on devinabox takes awhile for sidecars to connect to gm-control. Note this liveness probe is only on dashboard and data. Dashboard happens to already have this initial delay value and as such did not need to change.


<br/><br/>

2. What **changes to custom.yaml** are required?

None

<br/><br/>

3. Have you documented any additional setup steps or configurations options?

NA

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Ran in devinabox openshift and data's sidecars were connecting in time.

<br/><br/>
