### PR TITLE
User DN etc are now configurable

### DIFF
--- a/fabric/control-api/json/services/listener.json
+++ b/fabric/control-api/json/services/listener.json
@@ -60,7 +60,7 @@
                       "principal_name": {
                         "safe_regex": {
                           "google_re2": {},
-                          "regex": "spiffe:\/\/quickstart.greymatter.io\/(.+)"
+                          "regex": "spiffe:\/\/{{ .Values.global.spire.trust_domain }}\/(.+)"
                         }
                       }
                     }

--- a/fabric/control-api/json/services/listener.json
+++ b/fabric/control-api/json/services/listener.json
@@ -43,8 +43,8 @@
                   }],
                   "principals": [{
                       "header": {
-                          "name": "user_dn",
-                          "exact_match": "CN=quickstart,OU=Engineering,O=Decipher Technology Studios,L=Alexandria,ST=Virginia,C=US"
+                          "name": "{{ .Values.global.rbac.admin.header_name }}",
+                          "{{ .Values.global.rbac.admin.match_type }}": "{{ .Values.global.rbac.admin.header_value }}"
                       }
                 }]
               },
@@ -66,7 +66,7 @@
                     }
                   }
                 ]
-              },    
+              },
               "product-viewer": {
                   "permissions": [{
                       "header": {
@@ -90,11 +90,11 @@
       "prometheus_system_metrics_interval_seconds": 15,
       "metrics_key_function": "none"
     }{{-  if (.service.observablesEnabled) }},
-    "gm_observables": {	
-      "useKafka": true,	
-      "topic": "{{.service.serviceName}}",	
-      "eventTopic": "{{ .Values.global.observables.topic }}",	
-      "kafkaServerConnection": "{{ .Values.global.observables.kafkaServerConnection }}"	
+    "gm_observables": {
+      "useKafka": true,
+      "topic": "{{.service.serviceName}}",
+      "eventTopic": "{{ .Values.global.observables.topic }}",
+      "kafkaServerConnection": "{{ .Values.global.observables.kafkaServerConnection }}"
     }
     {{- end }}
   }

--- a/fabric/control-api/json/special/listener.json
+++ b/fabric/control-api/json/special/listener.json
@@ -30,8 +30,8 @@
                   }],
                   "principals": [{
                       "header": {
-                          "name": "user_dn",
-                          "exact_match": "CN=quickstart,OU=Engineering,O=Decipher Technology Studios,L=Alexandria,ST=Virginia,C=US"
+                        "name": "{{ .Values.global.rbac.admin.header_name }}",
+                        "{{ .Values.global.rbac.admin.match_type }}": "{{ .Values.global.rbac.admin.header_value }}"
                       }
                   }]
               },

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -2,13 +2,13 @@
 
 global:
   # Used as imagePullSecrets value for each subchart
-  image_pull_secret: docker.secret    
+  image_pull_secret: docker.secret
   # Deployment environment, one of "eks", "kuberenetes", or "openshift"
-  environment: openshift              
+  environment: openshift
   # Used to configure control and control-api environment variables
-  zone: zone-default-zone             
+  zone: zone-default-zone
   # Whether to use consul for service discovery
-  consul:                             
+  consul:
     enabled: false
     host: ''
     port: 8500
@@ -18,37 +18,42 @@ global:
   observables:
     topic: "greymatter"
   # Port for Grey Matter Control. Used in control, control-api, and sidecar envvars.
-  control_port: 50000  
+  control_port: 50000
   # Whether or not to use spire for cert management and the trust domain
   spire:
     enabled: false
-    trust_domain: quickstart.greymatter.io                
+    trust_domain: quickstart.greymatter.io
   # Configures the init container used to wait on various deployments to be ready
-  waiter:                             
+  waiter:
     image: deciphernow/k8s-waiter:latest
-    service_account: 
+    service_account:
       create: true
       name: waiter-sa
   # Global sidecar configuration
   sidecar:
     version: 1.3.0
     dn: C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=greymatter
-  
+  rbac:
+    admin:
+      header_name: user_dn
+      match_type: exact_match
+      header_value: CN=quickstart,OU=Engineering,O=Decipher Technology Studios,L=Alexandria,ST=Virginia,C=US
+
 controlApi:
   # Name used for the deployment and service resources
-  name: control-api                   
+  name: control-api
   # Display name used for NOTES.txt
-  display_name: control-api            
+  display_name: control-api
   # Number of replicas for the deployment
-  replicas: 1                         
+  replicas: 1
   version: 1.3.0
   image: 'docker-dev.production.deciphernow.com/deciphernow/gm-control-api:{{ .Values.controlApi.version }}'
   # When to pull images, used in the deployment
-  image_pull_policy: IfNotPresent       
+  image_pull_policy: IfNotPresent
   # Port exposed by the control-api container
-  container_port: 5555                                 
+  container_port: 5555
   # Location to persist control-api's configuration store
-  pvc_mount_point: '/app/control-api/data/backend.json' 
+  pvc_mount_point: '/app/control-api/data/backend.json'
   secret:
     enabled: true
     secret_name: controlapi-certs
@@ -122,12 +127,12 @@ sidecar:
       cpu: 100m
       memory: 128Mi
 
-  
+
 bootstrap:
   image: 'docker-dev.production.deciphernow.com/deciphernow/greymatter:1.3'
   image_pull_policy: IfNotPresent
-  secret:          
-    enabled: true  
+  secret:
+    enabled: true
     secret_name: sidecar-certs
     mount_point: /certs
     insecure: true
@@ -184,8 +189,8 @@ services:
     version: 1.0.1
     minInstances: 1
     maxInstances: 1
-    secret:          
-      enabled: true  
+    secret:
+      enabled: true
       secret_name: sidecar-certs
       mount_point: /etc/proxy/tls/sidecar
       insecure: true
@@ -219,8 +224,8 @@ services:
     routes:
       - '/services/dashboard/latest'
       - '/services/dashboard/latest/'
-    secret:          
-      enabled: true  
+    secret:
+      enabled: true
       secret_name: sidecar-certs
       mount_point: /etc/proxy/tls/sidecar
       insecure: true
@@ -237,7 +242,7 @@ services:
     serviceName: 'prometheus'
     observablesEnabled: false
     port: 9090
-    secret:          
+    secret:
       enabled: false
 
   data:
@@ -257,8 +262,8 @@ services:
     routes:
       - '/services/data/{{ $.Values.services.data.version }}'
       - '/services/data/{{ $.Values.services.data.version }}/'
-    secret:          
-      enabled: true  
+    secret:
+      enabled: true
       secret_name: sidecar-certs
       mount_point: /etc/proxy/tls/sidecar
       insecure: true
@@ -274,7 +279,7 @@ services:
     serviceName: 'data-internal'
     observablesEnabled: false
     port: 8181
-    enableInstanceMetrics: "true" 
+    enableInstanceMetrics: "true"
     capability: 'Data'
     jwt_prefix: '/jwt'
     documentation: '/services/data/latest/static/ui/index.html'
@@ -282,8 +287,8 @@ services:
     owner: 'Decipher'
     version: 1.0.0
     jwt_prefix: /jwt
-    secret:          
-      enabled: true  
+    secret:
+      enabled: true
       secret_name: sidecar-certs
       mount_point: /etc/proxy/tls/sidecar
       insecure: true
@@ -307,8 +312,8 @@ services:
     routes:
       - '/services/jwt-security/{{ $.Values.services.jwt.version }}'
       - '/services/jwt-security/{{ $.Values.services.jwt.version }}/'
-    secret:          
-      enabled: true  
+    secret:
+      enabled: true
       secret_name: sidecar-certs
       mount_point: /etc/proxy/tls/sidecar
       insecure: true
@@ -329,7 +334,7 @@ services:
     documentation: ''
     owner: 'Decipher'
     version: '0.2.0'
-    secret:          
+    secret:
       enabled: true
       secret_name: sidecar-certs
       mount_point: /etc/proxy/tls/sidecar
@@ -354,7 +359,7 @@ services:
     routes:
       - '/services/control-api/{{ $.Values.services.controlApi.version }}'
       - '/services/control-api/{{ $.Values.services.controlApi.version }}/'
-    secret:          
+    secret:
       enabled: true
       secret_name: sidecar-certs
       mount_point: /etc/proxy/tls/sidecar
@@ -414,7 +419,7 @@ services:
     routes:
       - '/services/slo/{{ $.Values.services.slo.version }}'
       - '/services/slo/{{ $.Values.services.slo.version }}/'
-    secret:          
+    secret:
       enabled: true
       secret_name: sidecar-certs
       mount_point: /etc/proxy/tls/sidecar

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -33,6 +33,7 @@ global:
   sidecar:
     version: 1.3.0
     dn: C=US,ST=Virginia,L=Alexandria,O=Decipher Technology Studios,OU=Engineering,CN=greymatter
+  # Global rbac configuration for service admin principal.
   rbac:
     admin:
       header_name: user_dn


### PR DESCRIPTION
Closes #580 

As you see in fabric/control-api/values.yaml, these were made configurable:
```
  rbac:
    admin:
      header_name: user_dn
      match_type: exact_match
      header_value: CN=quickstart,OU=Engineering,O=Decipher Technology Studios,L=Alexandria,ST=Virginia,C=US
```

If user_dn needs to be overridden, you can add something like the following to global.yaml:
```
  rbac:
    admin:
      header_value: new-value
```

How to test:

I removed lines for spire_volume_mount (control-api/templates/control-api.yaml) as it is to be dealt in another issue. But for references, the error looked like:
```
helm template fabric/control-api -f global.yaml --debug

install.go:158: [debug] Original chart version: ""
install.go:175: [debug] CHART PATH: /Users/hiromi/git/helm-charts/fabric/control-api

Error: template: control-api/templates/control-api.yaml:114:14: executing "control-api/templates/control-api.yaml" at <include "spire_volume_mount" .>: error calling include: template: no template "spire_volume_mount" associated with template "gotpl"
helm.go:75: [debug] template: control-api/templates/control-api.yaml:114:14: executing "control-api/templates/control-api.yaml" at <include "spire_volume_mount" .>: error calling include: template: no template "spire_volume_mount" associated with template "gotpl"
```

After that, run this command:
```
 helm template fabric/control-api -f global.yaml --debug > output
```

and make sure all listener.json has `new-value` instead of `CN=quickstart,OU=Engineering,O=Decipher Technology Studios,L=Alexandria,ST=Virginia,C=US`