### PR TITLE
If spire is disabled, the spire charts should not be installed 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,9 @@ check-secrets:
 install-spire:
 	@read -p "Would you like to install Spire? [y/N] " response; \
 	if [ "$$response" = "y" ]; then \
-        echo "Installing spire"; \
+		echo "Installing spire"; \
 		(cd spire && make spire); \
-    fi
+	fi
 
 .PHONY: install
 install: dev-dep check-secrets install-spire

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,16 @@ check-secrets:
 		(make secrets);\
 	fi
 
+.PHONY: install-spire
+install-spire:
+	@read -p "Would you like to install Spire? [y/N] " response; \
+	if [ "$$response" = "y" ]; then \
+        echo "Installing spire"; \
+		(cd spire && make spire); \
+    fi
+
 .PHONY: install
-install: dev-dep check-secrets
-	(cd spire && make spire)
+install: dev-dep check-secrets install-spire
 	(cd fabric && make fabric)
 	sleep 20
 	(cd edge && make edge)

--- a/docs/Deploy with K3d.md
+++ b/docs/Deploy with K3d.md
@@ -8,7 +8,7 @@
 ## Local Usage
 
 1. `make k3d` - start a kubernetes cluster locally.
-1. `export KUBECONFIG="$(k3d get-kubeconfig --name='greymatter')" ` - configures `kubectl` to use the local k3d cluster.
+1. `export KUBECONFIG="$(k3d get-kubeconfig --name='greymatter')"` - configures `kubectl` to use the local k3d cluster.
 1. `make credentials` - creates a git ignored file `credentials.yaml` 
 1. `make secrets` - inserts data from `credentials.yaml` and `secrets/values.yaml` into the cluster as secrets.
 1. `make install` installs each helm chart (spire, fabric, edge, data, sense). This will take about 1.5 minutes.


### PR DESCRIPTION
Closes #588 

Added a question regarding whether or not to install spire. When you run `make install`, the only way spire will be installed is for you to type `y` - everything else is considered as no.

Also the change for `docs/Deploy with K3d.md` is removing a strange character:
<img width="1365" alt="Screen Shot 2020-05-04 at 6 34 30 PM" src="https://user-images.githubusercontent.com/5401333/81023445-06b31800-8e36-11ea-820f-91fcb1254a6e.png">

