### PR TITLE
[release-2.2] fixes the logic for the edge ingress to use voyager

### DIFF
--- a/edge/templates/edge-ingress.yaml
+++ b/edge/templates/edge-ingress.yaml
@@ -1,3 +1,22 @@
+{{/*
+Defines the edge ingress.  can be reused by passing in annotations, rules, and apiVersion
+*/}}
+{{- define "edge-ingress" }}
+{{- $ingress := index . "ingress" }}
+{{- $root := index . "root" }}
+apiVersion: {{ $ingress.apiVersion }}
+kind: Ingress
+metadata:
+  name: edge
+  namespace: {{ $root.Release.Namespace }}
+  annotations:
+{{ toYaml $ingress.annotations | indent 4 }}
+spec:
+  rules:
+{{ toYaml $ingress.rules | indent 4 }}
+{{- end }}
+
+
 {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
 kind: Route
 apiVersion: route.openshift.io/v1
@@ -17,38 +36,17 @@ spec:
   wildcardPolicy: None
 
 {{- else }}
-{{- with .Values.edge.ingress.nginx }}
 
-
-{{- if .use_voyager -}}
-
-# with voyager
-apiVersion: {{ .apiVersion }}
-kind: Ingress
-metadata:
-  name: edge
-  namespace: {{ $.Release.Namespace }}
-  annotations:
-{{ toYaml .annotations | indent 4 }}
-spec:
-  rules:
-{{ toYaml .rules | indent 4 }}
+# Create nginx or voyager ingress using template
+{{- $root := . }}
+{{- if .Values.edge.ingress.use_voyager }}
+{{- $ingress := .Values.edge.ingress.voyager }}
+{{- include "edge-ingress" (dict "ingress" $ingress "root" $root) }}
 
 {{- else }}
-# with nginx
+{{- $ingress := .Values.edge.ingress.nginx}}
+{{- include "edge-ingress" (dict "ingress" $ingress "root" $root) }}
 
-apiVersion: {{ .apiVersion }}
-kind: Ingress
-metadata:
-  name: edge
-  namespace: {{ $.Release.Namespace }}
-  annotations:
-{{ toYaml .annotations | indent 4 }}
-spec:
-  rules:
-{{ toYaml .rules | indent 4 }}
+{{- end }} 
 
-{{- end }}
-
-{{- end }} #end with ingress
 {{- end }}

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -90,6 +90,7 @@ edge:
     # If global.environment is openshift, a passthrough Route is configured with host set from the values specified in global.domain, global.route_url_name, and global.remove_namespace_from_url
     # If global.environment is not openshift, an ingress object is created with the specified apiVersion, annotations, and rules
     
+    # If use_voyager is true make sure voyager is already installed
     use_voyager: false
     voyager:
       apiVersion: voyager.appscode.com/v1beta1


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This eliminates the duplicate code described in issue #595 and also fixes the ingress code logic that prevented voyager from being used as an ingress

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

no additional documentation

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

- start with a clean cluster run `make destroy` and then `make k3d`

*ensure nginx will install*
- run `make secrets` and `make install`
- ensure you can hit the dashboard at https://localhost:30000
- clean up `make delete`

*ensure voyager will work*
- install voyager: run `cd voyager && make voyager && cd ..`
- in `edge/values.yaml` change `use_voyager` to  `true`
- run `make install`
 - ensure you can hit the dashboard at https://localhost:30000

- clean up with `make destroy`