### PR TITLE
use global.yaml spire.enabled value to decide to install spire or not

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,18 +45,14 @@ dev-dep: clean
 .PHONY: check-secrets
 check-secrets:
 	$(eval SECRET_CHECK=$(shell helm ls | grep secrets | awk '{if ($$1 == "secrets") print "present"; else print "not-present"}'))
-	echo $(SECRET_CHECK)
 	if [[ "$(SECRET_CHECK)" != "present" ]]; then \
-		echo "present" ;\
 		(make secrets);\
 	fi
 
 .PHONY: install-spire
 install-spire:
 	$(eval IS=$(shell grep -A3 'spire:' global.yaml | grep enabled: | awk '{print $$2}'))
-	echo $(IS)
 	if [ "$(IS)" = "true" ]; then \
-		echo "Installing spire"; \
 		(cd spire && make spire); \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ check-secrets:
 
 .PHONY: install-spire
 install-spire:
-	$(eval IS=$(shell grep -A3 'spire:' global.yaml | grep enabled: | awk '{print $$2}'))
+	$(eval IS=$(shell cat global.yaml | grep -A3 'spire:'| grep enabled: | awk '{print $$2}'))
 	if [ "$(IS)" = "true" ]; then \
 		(cd spire && make spire); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,9 @@ check-secrets:
 
 .PHONY: install-spire
 install-spire:
-	@read -p "Would you like to install Spire? [y/N] " response; \
-	if [ "$$response" = "y" ]; then \
+	$(eval IS=$(shell grep -A3 'spire:' global.yaml | grep enabled: | awk '{print $$2}'))
+	echo $(IS)
+	if [ "$(IS)" = "true" ]; then \
 		echo "Installing spire"; \
 		(cd spire && make spire); \
 	fi


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Updates the install-spire makefile target to use the `global.spire.enabled` value to determine if helm should install spire.

2. What **changes to custom.yaml** are required?

None

3. Have you documented any additional setup steps or configurations options?

None needed

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Change the `global.spire.enabled=true` and run `make install-spire` To verify it installs use `kubectl get pods --all-namespaces`.

Follow the same with false to ensure spire is not installed.
