### PR TITLE
update secrets to allow in rds certs over a global cert and include a…

### DIFF
--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -8,39 +8,30 @@ pwd_name := $(notdir $(PWD))
 
 .PHONY: credentials
 credentials:
-	@if [ "$(pwd_name)" == "helm-charts" ]; then \
-		./ci/scripts/build-credentials.sh; \
-	elif [ "$(pwd_name)" == "secrets" ]; then \
-		./../ci/scripts/build-credentials.sh; \
-	else \
-		echo "Make sure you are running this from helm-charts or secrets makefile"; \
-	fi
+	./../ci/scripts/build-credentials.sh
 
 copy-credentials:
-	@if [ "$(pwd_name)" == "helm-charts" ]; then \
-		cp ./credentials.yaml ./secrets/credentials.yaml; \
-	elif [ "$(pwd_name)" == "secrets" ]; then \
-		cp ../credentials.yaml .; \
-	else \
-		echo "Make sure you are running this from helm-charts or secrets makefile"; \
-	fi
+	cp ../credentials.yaml .
 
 template-secrets: $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
 	helm template secrets . --set=global.environment=kubernetes   -f ../credentials.yaml -f ../global.yaml > $(OUTPUT_PATH)/helm-secrets$(BN).yaml
 
 .PHONY: secrets
-secrets: copy-credentials
-	@if [ "$(pwd_name)" == "helm-charts" ]; then \
-		helm install secrets secrets -f credentials.yaml -f global.yaml; \
-		rm secrets/credentials.yaml; \
-	elif [ "$(pwd_name)" == "secrets" ]; then \
-		helm install secrets . -f credentials.yaml -f ../global.yaml; \
-		rm credentials.yaml; \
-	else \
-		echo "Make sure you are running this from helm-charts or secrets makefile"; \
-	fi
+secrets: copy-credentials values-validation
+	helm install secrets . -f credentials.yaml -f ../global.yaml
+	rm credentials.yaml
 
 .PHONY: remove-secrets
 remove-secrets:
 	helm uninstall secrets
+
+
+values-validation:
+	# Ensure that the rds.enabled is true in secrets and in fabric values files
+	@if [ "$(shell cat values.yaml | grep -A1 rds | grep enabled: | awk '{print $$2}')" == "$(shell cat ../sense/values.yaml | grep -A1 rds | grep enabled: | awk '{print $$2}')" ]; then \
+		echo "rds.enabled in secrets/values.yaml and sense/values.yaml match"; \
+	else \
+		echo "rds.enabled in secrets/values.yaml and sense/values.yaml DO NOT MATCH.  Secrets will not be created"; \
+		exit 2;\
+	fi

--- a/secrets/templates/postgres-certs.yaml
+++ b/secrets/templates/postgres-certs.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.global_certs.enabled }}
+{{- if or (not .Values.global.global_certs.enabled) ( .Values.postgres.rds.enabled ) }}
 {{- if .Values.postgres.ssl.enabled }}
 {{ if .Values.postgres.ssl.certificates }}
 ---

--- a/secrets/values.yaml
+++ b/secrets/values.yaml
@@ -510,6 +510,8 @@ postgres:
     username: greymatter
     password: greymatter
     database: greymatter
+  rds:
+    enabled: true
   ssl:
     enabled: true
     name: postgres-ssl-certs
@@ -691,7 +693,7 @@ internaljwt:
         PK57iQEQz3QrshXB5nrvhAjKfiESo++zFmkZUAqgTjrox2EJUjtHFx40YbFe1Vrf
         N69uc/UauO74PKYWRWU=
         -----END PUBLIC KEY-----
-      jwt.api_key: dm9sY2Fuby1lcGlkZW1pYy10d2VsZnRoLXRhbWFsZQ==
+      # jwt_api_key: dm9sY2Fuby1lcGlkZW1pYy10d2VsZnRoLXRhbWFsZQ==
     certs:
       name: internal-jwt-certs
       # If from_file is true then you need to place cert files into the direcroty specified in path
@@ -1302,7 +1304,7 @@ jwt:
         PK57iQEQz3QrshXB5nrvhAjKfiESo++zFmkZUAqgTjrox2EJUjtHFx40YbFe1Vrf
         N69uc/UauO74PKYWRWU=
         -----END PUBLIC KEY-----
-      jwt.api_key: dm9sY2Fuby1lcGlkZW1pYy10d2VsZnRoLXRhbWFsZQ==
+      # jwt.api_key: dm9sY2Fuby1lcGlkZW1pYy10d2VsZnRoLXRhbWFsZQ==
 
 sidecar:
   certificates:

--- a/secrets/values.yaml
+++ b/secrets/values.yaml
@@ -693,7 +693,7 @@ internaljwt:
         PK57iQEQz3QrshXB5nrvhAjKfiESo++zFmkZUAqgTjrox2EJUjtHFx40YbFe1Vrf
         N69uc/UauO74PKYWRWU=
         -----END PUBLIC KEY-----
-      # jwt_api_key: dm9sY2Fuby1lcGlkZW1pYy10d2VsZnRoLXRhbWFsZQ==
+      jwt.api_key: dm9sY2Fuby1lcGlkZW1pYy10d2VsZnRoLXRhbWFsZQ==
     certs:
       name: internal-jwt-certs
       # If from_file is true then you need to place cert files into the direcroty specified in path
@@ -1304,7 +1304,7 @@ jwt:
         PK57iQEQz3QrshXB5nrvhAjKfiESo++zFmkZUAqgTjrox2EJUjtHFx40YbFe1Vrf
         N69uc/UauO74PKYWRWU=
         -----END PUBLIC KEY-----
-      # jwt.api_key: dm9sY2Fuby1lcGlkZW1pYy10d2VsZnRoLXRhbWFsZQ==
+      jwt.api_key: dm9sY2Fuby1lcGlkZW1pYy10d2VsZnRoLXRhbWFsZQ==
 
 sidecar:
   certificates:

--- a/sense/slo/templates/slo.yaml
+++ b/sense/slo/templates/slo.yaml
@@ -100,7 +100,9 @@ spec:
       {{- if .Values.postgres.secret.enabled }}
       - name: postgres-certs
         secret:
-          {{- if .Values.global.global_certs.enabled }}
+          {{- if .Values.postgres.rds.enabled }}
+          secretName:  {{ .Values.postgres.secret.secret_name }}
+          {{- else if .Values.global.global_certs.enabled }}
           secretName: global-certs
           {{- else }}
           secretName: {{ .Values.postgres.secret.secret_name }}


### PR DESCRIPTION
… check in secrets to ensure rds.enables values match

**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

<br/><br/>

2. What **changes to custom.yaml** are required?

adds rds.enabled under posgres in the secrets/values.yaml file

3. Have you documented any additional setup steps or configurations options?

none needed.  there is however a check to make sure that if the sense rds enabled matches the secrets rds enabled values

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

*start*
with a clean k3d cluster
`make credentials`
set global_certs true in global.yaml
`make secrets`
check secrets with `kc get secrets | grep postgres` ensure postgres-ssl-certs is not listed
`make remove secrets`

*Make sure value validator works*
set `postgres.rds.enabled` to true in `secrets/values.yaml` and leave it false in `sense/values.yaml`
`make secrets`
The make target should exit with an error 2

*Create special for rds*
set `postgres.rds.enabled` to true in `secrets/values.yaml` and `sense/values.yaml`
in `secrets/values.yaml` set `postgres .ssl.certificates.ca` to "apples"
`make secrets`
check secrets with `kc get secrets | grep postgres` ensure postgres-ssl-certs is listed
check to ensure your cert was processed correctly with `kc get secrets postgres-ssl-certs -o yaml`. Copy the ca value and base6d decode it.  you should get apples.
