### PR TITLE
fix edge listener jwt rbac

### DIFF
--- a/fabric/control-api/json/special/listener.json
+++ b/fabric/control-api/json/special/listener.json
@@ -7,7 +7,7 @@
   "port": 10808,
   "protocol": "http_auto",
   "tracing_config": null,
-  "active_http_filters": ["gm.metrics", "gm.inheaders", "gm.jwtsecurity", "envoy_jwt_authn", "envoy.rbac"],
+  "active_http_filters": ["gm.metrics", "gm.inheaders", "gm.jwtsecurity", "envoy.jwt_authn", "envoy.rbac"],
   "http_filters": {
     "gm_inheaders": {},
     "gm_metrics": {
@@ -65,12 +65,19 @@
                       "key": "claims"
                     },
                     {
+                      "key": "values"
+                    },
+                    {
                       "key": "email"
                     }
                   ],
                   "value": {
-                    "string_match": {
-                      "suffix": "greymatter.io"
+                    "list_match": {
+                      "one_of": {
+                        "string_match": {
+                          "suffix": "greymatter.io"
+                        }
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

closes #672 

Properly enables the jwt_authn filter and fixes rbac config on edge to get email claim

2. What **changes to custom.yaml** are required?

None


To test:

Run `make install` and check the edge logs - you should see the following at startup to indicate that the jwt_authn filter is on:

```bash
[2020-07-02 14:12:18.714][9][info][jwt] [bazel-out/k8-fastbuild/bin/external/envoy/source/extensions/filters/http/jwt_authn/_virtual_includes/filter_config_interface/extensions/filters/http/jwt_authn/filter_config.h:70] Loaded JwtAuthConfig: providers {
  key: "greymatter"
  value {
    issuer: "greymatter.io"
    local_jwks {
      inline_string: "{\'keys\':[{\'crv\': \'P-521\',\'kid\': \'1\',\'kty\': \'EC\',\'x\': \'DxZd8I_IS4Am6jfjKNaqsAxWfxhweN6I081jLgq6hTL-qlReYXd62kH3v-chAWtqWKILz1CM-reeh5hlZ3qsDf4\',\'y\': \'AWs6sDyue4kBEM90K7IVweZ674QIyn4hEqPvsxZpGVAKoE466MdhCVI7RxceNGGxXtVa3zevbnP1Grju-DymFkVl\'}]}"
      183412668: "envoy.api.v2.core.DataSource"
    }
    from_headers {
      name: "userpolicy"
      183412668: "envoy.config.filter.http.jwt_authn.v2alpha.JwtHeader"
    }
    payload_in_metadata: "claims"
    183412668: "envoy.config.filter.http.jwt_authn.v2alpha.JwtProvider"
  }
}
rules {
  match {
    prefix: "/"
    183412668: "envoy.api.v2.route.RouteMatch"
  }
  requires {
    provider_name: "greymatter"
    183412668: "envoy.config.filter.http.jwt_authn.v2alpha.JwtRequirement"
  }
  183412668: "envoy.config.filter.http.jwt_authn.v2alpha.RequirementRule"
}
183412668: "envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication"
```

Now `greymatter edit listener edge-listener` and delete the other two rbac policies, `admin_dn` and `anonymous` . (you may need to bounce edge now to take effect). Nav to `https://localhost:30000` and you should no longer be rejected with `RBAC: access denied` (the previous behavior)