### PR TITLE
651 egress

### DIFF
--- a/data/gm-data/values.yaml
+++ b/data/gm-data/values.yaml
@@ -148,7 +148,7 @@ data:
     # Use data's egress listener port
     client_jwt_endpoint_port:
       type: value
-      value: '{{- if .Values.global.spire.enabled }}10909{{- else}}10808{{- end }}'
+      value: '10909'
     client_jwt_endpoint_prefix:
       type: value
       value: '/jwt'

--- a/data/values.yaml
+++ b/data/values.yaml
@@ -181,7 +181,7 @@ data:
         value: localhost
       client_jwt_endpoint_port:
         type: value
-        value: '{{- if .Values.global.spire.enabled }}10909{{- else}}10808{{- end }}'
+        value: '10909'
       client_jwt_endpoint_prefix:
         type: value
         value: /jwt
@@ -357,7 +357,7 @@ internal-data:
         value: localhost
       client_jwt_endpoint_port:
         type: value
-        value: '{{- if .Values.global.spire.enabled }}10909{{- else}}10808{{- end }}'
+        value: '10909'
       client_jwt_endpoint_prefix:
         type: value
         value: /jwt

--- a/fabric/control-api/config/bootstrap.sh
+++ b/fabric/control-api/config/bootstrap.sh
@@ -105,17 +105,17 @@ done
 
 cd $MESH_CONFIG_DIR/special
 
-if $SPIRE_ENABLED; then
-    echo "Adding internal clusters"
-    for cl in $(ls internal-cluster-*.json); do
-        create_or_update "cluster" $cl
-    done
 
-    echo "Adding internal shared_rules"
-    for sr in $(ls internal-shared-rules-*.json); do
-        create_or_update "shared_rules" $sr
-    done
-fi
+echo "Adding egress clusters"
+for cl in $(ls internal-cluster-*.json); do
+    create_or_update "cluster" $cl
+done
+
+echo "Adding egress shared_rules"
+for sr in $(ls internal-shared-rules-*.json); do
+    create_or_update "shared_rules" $sr
+done
+
 
 echo "Adding additional Special Routes"
 for rte in $(ls route-*.json); do

--- a/fabric/control-api/json/special/internal-cluster-catalog-data-internal.json
+++ b/fabric/control-api/json/special/internal-cluster-catalog-data-internal.json
@@ -2,6 +2,7 @@
   "cluster_key": "catalog-to-data-internal-cluster",
   "zone_key": "zone-default-zone",
   "name": "data-internal",
+  {{- if .Values.global.spire.enabled }}
   "require_tls": true,
   "secret": {
     "secret_key": "secret-data-internal-secret",
@@ -14,6 +15,19 @@
       "spiffe://{{ .Values.global.spire.trust_domain}}/data-internal"
     ]
   },
+  {{- else if .Values.services.catalog.secret.enabled }}
+  "require_tls": true,
+  "ssl_config": {
+    "require_client_certs": true,
+    "trust_file": "/etc/proxy/tls/sidecar/ca.crt",
+    "cert_key_pairs": [
+      {
+        "certificate_path": "/etc/proxy/tls/sidecar/server.crt",
+        "key_path": "/etc/proxy/tls/sidecar/server.key"
+      }
+    ]
+  },
+  {{- end }}
   "circuit_breakers": null,
   "outlier_detection": null,
   "health_checks": []

--- a/fabric/control-api/json/special/internal-cluster-data-to-jwt-extdata.json
+++ b/fabric/control-api/json/special/internal-cluster-data-to-jwt-extdata.json
@@ -2,6 +2,7 @@
   "cluster_key": "data-to-jwt-cluster",
   "zone_key": "zone-default-zone",
   "name": "jwt-security",
+  {{- if .Values.global.spire.enabled }}
   "require_tls": true,
   "secret": {
     "secret_key": "secret-jwt-security-secret",
@@ -14,6 +15,19 @@
       "spiffe://{{ .Values.global.spire.trust_domain}}/jwt-security"
     ]
   },
+  {{- else if .Values.services.data.secret.enabled }}
+  "require_tls": true,
+  "ssl_config": {
+    "require_client_certs": true,
+    "trust_file": "/etc/proxy/tls/sidecar/ca.crt",
+    "cert_key_pairs": [
+      {
+        "certificate_path": "/etc/proxy/tls/sidecar/server.crt",
+        "key_path": "/etc/proxy/tls/sidecar/server.key"
+      }
+    ]
+  },
+  {{- end }}
   "circuit_breakers": null,
   "outlier_detection": null,
   "health_checks": []

--- a/fabric/control-api/json/special/internal-cluster-int-data-to-int-jwt.json
+++ b/fabric/control-api/json/special/internal-cluster-int-data-to-int-jwt.json
@@ -2,6 +2,7 @@
     "cluster_key": "data-internal-to-internal-jwt-cluster",
     "zone_key": "zone-default-zone",
     "name": "internal-jwt-security",
+    {{- if .Values.global.spire.enabled }}
     "require_tls": true,
     "secret": {
       "secret_key": "secret-internal-jwt-security-secret",
@@ -14,6 +15,19 @@
         "spiffe://{{ .Values.global.spire.trust_domain}}/internal-jwt-security"
       ]
     },
+    {{- else if index .Values.services "internal-data" "secret" "enabled" }}
+    "require_tls": true,
+    "ssl_config": {
+      "require_client_certs": true,
+      "trust_file": "/etc/proxy/tls/sidecar/ca.crt",
+      "cert_key_pairs": [
+        {
+          "certificate_path": "/etc/proxy/tls/sidecar/server.crt",
+          "key_path": "/etc/proxy/tls/sidecar/server.key"
+        }
+      ]
+    },
+    {{- end }}
     "circuit_breakers": null,
     "outlier_detection": null,
     "health_checks": []

--- a/fabric/control-api/json/special/route-catalog-to-internal-data-slash.json
+++ b/fabric/control-api/json/special/route-catalog-to-internal-data-slash.json
@@ -1,19 +1,11 @@
 {
   "route_key": "catalog-internal-data-route-slash",
-  {{- if .Values.global.spire.enabled }}
   "domain_key": "domain-catalog-egress",
-  {{- else }}
-  "domain_key": "domain-catalog",
-  {{- end }}
   "zone_key": "{{ .Values.global.zone}}",
   "path": "{{ .Values.services.catalog.data_prefix }}",
   "prefix_rewrite": "{{ .Values.services.catalog.data_prefix }}/",
   "redirects": null,
-  {{- if .Values.global.spire.enabled }}
   "shared_rules_key": "catalog-data-internal-shared-rules",
-  {{- else }}
-  "shared_rules_key": "edge-data-internal-shared-rules",
-  {{- end }}
   "rules": null,
   "response_data": {},
   "cohort_seed": null,

--- a/fabric/control-api/json/special/route-catalog-to-internal-data.json
+++ b/fabric/control-api/json/special/route-catalog-to-internal-data.json
@@ -1,19 +1,11 @@
 {
   "route_key": "catalog-internal-data-route",
-  {{- if .Values.global.spire.enabled }}
   "domain_key": "domain-catalog-egress",
-  {{- else }}
-  "domain_key": "domain-catalog",
-  {{- end }}
   "zone_key": "{{ .Values.global.zone}}",
   "path": "{{ .Values.services.catalog.data_prefix }}/",
   "prefix_rewrite": "/",
   "redirects": null,
-  {{- if .Values.global.spire.enabled }}
   "shared_rules_key": "catalog-data-internal-shared-rules",
-  {{- else }}
-  "shared_rules_key": "edge-data-internal-shared-rules",
-  {{- end }}
   "rules": null,
   "response_data": {},
   "cohort_seed": null,

--- a/fabric/control-api/json/special/route-data-jwt-extdata.json
+++ b/fabric/control-api/json/special/route-data-jwt-extdata.json
@@ -1,19 +1,11 @@
 {
   "route_key": "data-jwt-route",
-  {{- if .Values.global.spire.enabled }}
   "domain_key": "domain-data-egress",
-  {{- else }}
-  "domain_key": "domain-data",
-  {{- end }}
   "zone_key": "{{ .Values.global.zone}}",
   "path": "{{ .Values.services.data.jwt_prefix }}/",
   "prefix_rewrite": "/",
   "redirects": null,
-  {{- if .Values.global.spire.enabled }}
   "shared_rules_key": "data-jwt-shared-rules",
-  {{- else }}
-  "shared_rules_key": "edge-jwt-security-shared-rules",
-  {{- end }}
   "rules": null,
   "response_data": {},
   "cohort_seed": null,

--- a/fabric/control-api/json/special/route-data-jwt-slash-extdata.json
+++ b/fabric/control-api/json/special/route-data-jwt-slash-extdata.json
@@ -1,19 +1,11 @@
 {
   "route_key": "data-jwt-route-slash",
-  {{- if .Values.global.spire.enabled }}
   "domain_key": "domain-data-egress",
-  {{- else }}
-  "domain_key": "domain-data",
-  {{- end }}
   "zone_key": "{{ .Values.global.zone}}",
   "path": "{{ .Values.services.data.jwt_prefix }}",
   "prefix_rewrite": "{{ .Values.services.data.jwt_prefix }}/",
   "redirects": null,
-  {{- if .Values.global.spire.enabled }}
   "shared_rules_key": "data-jwt-shared-rules",
-  {{- else }}
-  "shared_rules_key": "edge-jwt-security-shared-rules",
-  {{- end }}
   "rules": null,
   "response_data": {},
   "cohort_seed": null,

--- a/fabric/control-api/json/special/route-int-data-int-jwt-slash.json
+++ b/fabric/control-api/json/special/route-int-data-int-jwt-slash.json
@@ -1,19 +1,11 @@
 {
     "route_key": "route-data-internal-internal-jwt-slash",
-    {{- if .Values.global.spire.enabled }}
     "domain_key": "domain-data-internal-egress",
-    {{- else }}
-    "domain_key": "domain-data-internal",
-    {{- end }}
     "zone_key": "{{ .Values.global.zone}}",
     "path": "/jwt/",
     "prefix_rewrite": "/",
     "redirects": null,
-    {{- if .Values.global.spire.enabled }}
     "shared_rules_key": "shared-rules-data-internal-to-internal-jwt",
-    {{- else }}
-    "shared_rules_key": "edge-internal-jwt-security-shared-rules",
-    {{- end }}
     "rules": null,
     "response_data": {},
     "cohort_seed": null,

--- a/fabric/control-api/json/special/route-int-data-int-jwt.json
+++ b/fabric/control-api/json/special/route-int-data-int-jwt.json
@@ -1,19 +1,11 @@
 {
     "route_key": "route-data-internal-internal-jwt",
-    {{- if .Values.global.spire.enabled }}
     "domain_key": "domain-data-internal-egress",
-    {{- else }}
-    "domain_key": "domain-data-internal",
-    {{- end }}
     "zone_key": "{{ .Values.global.zone}}",
     "path": "/jwt",
     "prefix_rewrite": "/jwt/",
     "redirects": null,
-    {{- if .Values.global.spire.enabled }}
     "shared_rules_key": "shared-rules-data-internal-to-internal-jwt",
-    {{- else }}
-    "shared_rules_key": "edge-internal-jwt-security-shared-rules",
-    {{- end }}
     "rules": null,
     "response_data": {},
     "cohort_seed": null,

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -162,9 +162,6 @@ bootstrap:
     basic_object_path:
       value: '/tmp/mesh/basic_objects'
       type: 'value'
-    spire_enabled:
-      type: 'value'
-      value: '{{ .Values.global.spire.enabled }}'
     greymatter_api_ssl:
       type: value
       value: '{{ .Values.bootstrap.secret.enabled }}'

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -238,9 +238,6 @@ control-api:
       greymatter_api_ssl:
         type: value
         value: '{{ not .Values.global.spire.enabled }}'
-      spire_enabled:
-        type: 'value'
-        value: '{{ .Values.global.spire.enabled }}'
 
 
 # Services list used to create Grey Matter configuration objects in control-api/config

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -372,7 +372,7 @@ catalog:
         value: localhost
       client_port:
         type: value
-        value: '{{- if .Values.global.spire.enabled }}10909{{- else}}10808{{- end }}'
+        value: '10909'
       client_prefix:
         type: value
         value: '/data'


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.
<br/><br/>

closes #651 

This updates mesh configs and service env vars to use egress domains for internal routes in the non-spire install

<br/><br/>

2. What **changes to custom.yaml** are required?

None


Details:

This PR does a couple of things to update the egress routing:

- updates any service env vars making requests to other services in the mesh to go through their egress listener port (10909). These egress listeners/domains are [already created and applied](https://github.com/DecipherNow/helm-charts/blob/9623b425f72f896d4720187f1af0db4df84a8d60/fabric/control-api/config/bootstrap.sh#L58-L60) and just have not been used
- updates the internal routes (catalog -> internal-data -> internal-jwt) to set those routes on the egress domains so the request generated by the service above goes through the egress listener on 10909, which has the proper route set to point to the next service
- generates an internal-cluster with an ssl config for all internal routes and unique shared-rules objects for those clusters (the same way spiffe/spire does) now applied [here](https://github.com/DecipherNow/helm-charts/blob/2f76a6c904b3c04ee489e07b16496dcd46551691/fabric/control-api/config/bootstrap.sh#L109-L117). The reason for this:
    - current behavior reuses the `edge-to-serviceB-cluster` for any internal route from serviceA to serviceB - for example using `edge-to-data-internal-cluster` for catalog -> data-internal route [here](https://github.com/DecipherNow/helm-charts/blob/9623b425f72f896d4720187f1af0db4df84a8d60/fabric/control-api/json/special/route-catalog-to-internal-data.json#L15). This is technically fine based on the way the helm charts work and configure ssl, but logically not quite right.  It only works because all sidecars by default use the quickstart certs and mount them at the same place, so [this ssl_config](https://github.com/DecipherNow/helm-charts/blob/9623b425f72f896d4720187f1af0db4df84a8d60/fabric/control-api/json/edge/cluster.json#L23-L32) is the same as this [ssl_config](https://github.com/DecipherNow/helm-charts/blob/2f76a6c904b3c04ee489e07b16496dcd46551691/fabric/control-api/json/special/internal-cluster-catalog-data-internal.json#L20-L29) which is why reusing this edge cluster works. In any case where certs mounted into the catalog container are not named `server.crt`, `server.key` etc or mounted at the same place `/etc/proxy/tls/sidecar/` this logic fails, so i made this particular change mainly for clarity for people trying to adapt the helm charts to a more specific configuration


The first two points are directly aligned with the issue, and the third is more of an addition to help clean up the egress logic. 
