### PR TITLE
add missing ImagePullPolicy for catalog-init job

### DIFF
--- a/sense/catalog/templates/catalog-init-hook.yaml
+++ b/sense/catalog/templates/catalog-init-hook.yaml
@@ -18,7 +18,7 @@ spec:
       initContainers:
         - name: ensure-{{ .Values.catalog.name }}
           image: {{ .Values.global.waiter.image }}
-          imagePullPolicy: {{ .Values.catalog.init.image_pull_policy }}
+          imagePullPolicy: {{ .Values.catalog.init.imagePullPolicy }}
           env:
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
@@ -27,7 +27,7 @@ spec:
       containers:
         - image: {{ tpl .Values.catalog.init.image . }}
           name: {{ .Values.catalog.name }}-init
-          imagePullPolicy: {{ .Values.catalog.init.image_pull_policy }}
+          imagePullPolicy: {{ .Values.catalog.init.imagePullPolicy }}
           command: ["/tmp/bootstrap/bootstrap.sh"]
           env:
           {{- include "envvars" (dict "envvar" .Values.catalog.init.envvars "top" $) | indent 12 }}

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -40,7 +40,7 @@ global:
       name: waiter-sa
   # Global sidecar configuration (supports global version and envvars)
   sidecar:
-    version: 1.4.4
+    version: 1.4.2
     envvars:
       proxy_dynamic:
         type: 'value'
@@ -423,7 +423,6 @@ catalog:
         use_tls:
           type: value
           value: '{{ not .Values.global.spire.enabled }}'
-      image_pull_policy
 
 # Services list used to configure Catalog, which populates service metadata for GM Dashboard
 services:
@@ -615,7 +614,7 @@ services:
     capability: 'Mesh'
     documentatio: ''
     owner: 'Decipher'
-    version: '1.4.4'
+    version: '1.4.2'
     secret:
       enabled: true
       secret_name: sidecar-certs

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -40,7 +40,7 @@ global:
       name: waiter-sa
   # Global sidecar configuration (supports global version and envvars)
   sidecar:
-    version: 1.4.2
+    version: 1.4.4
     envvars:
       proxy_dynamic:
         type: 'value'
@@ -423,6 +423,7 @@ catalog:
         use_tls:
           type: value
           value: '{{ not .Values.global.spire.enabled }}'
+      image_pull_policy
 
 # Services list used to configure Catalog, which populates service metadata for GM Dashboard
 services:
@@ -614,7 +615,7 @@ services:
     capability: 'Mesh'
     documentatio: ''
     owner: 'Decipher'
-    version: '1.4.2'
+    version: '1.4.4'
     secret:
       enabled: true
       secret_name: sidecar-certs


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

catalog-init job wasn't being created. I noticed that the image pull policy was missing, after adding it back the job was created and ran successfully. 

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

I installed on k3d and ensured that services were bootstrapped successfully.
