### PR TITLE
Removing if statements

### DIFF
--- a/data/gm-data/templates/_envvars.tpl
+++ b/data/gm-data/templates/_envvars.tpl
@@ -32,11 +32,8 @@
       name: {{ $e.secret }}
       key: {{ $e.key }}
           {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
-            {{- end }}
           {{- end }}
 {{- end }}
 

--- a/edge/templates/_envvars.tpl
+++ b/edge/templates/_envvars.tpl
@@ -11,11 +11,8 @@
       name: {{ $e.secret }}
       key: {{ $e.key }}
           {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
-            {{- end }}
           {{- end }}
 {{- end }}
 

--- a/fabric/control-api/templates/_envvars.tpl
+++ b/fabric/control-api/templates/_envvars.tpl
@@ -31,13 +31,10 @@
     secretKeyRef:
       name: {{ $e.secret }}
       key: {{ $e.key }}
-          {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
+        {{- else if eq $e.type "value" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
-            {{- end }}
-          {{- end }}
+        {{- end }}
 {{- end }}
 
 {{- /*  envvars loops through the global sidecar envvars and generates Kubernetes container env keys for both regular values and secrets from the local sidecar values and from the global values as a backup.

--- a/fabric/jwt-gov/templates/_envvars.tpl
+++ b/fabric/jwt-gov/templates/_envvars.tpl
@@ -32,11 +32,8 @@
       name: {{ $e.secret }}
       key: {{ $e.key }}
           {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
-            {{- end }}
           {{- end }}
 {{- end }}
 

--- a/fabric/jwt/templates/_envvars.tpl
+++ b/fabric/jwt/templates/_envvars.tpl
@@ -32,11 +32,8 @@
       name: {{ $e.secret }}
       key: {{ $e.key }}
           {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
-            {{- end }}
           {{- end }}
 {{- end }}
 

--- a/fabric/redis/templates/_envvars.tpl
+++ b/fabric/redis/templates/_envvars.tpl
@@ -32,10 +32,7 @@
       name: {{ $e.secret }}
       key: {{ $e.key }}
           {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
-            {{- end }}
           {{- end }}
 {{- end }}

--- a/sense/catalog/templates/_envvars.tpl
+++ b/sense/catalog/templates/_envvars.tpl
@@ -30,11 +30,8 @@
       name: {{ $e.secret }}
       key: {{ $e.key }}
           {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
-            {{- end }}
           {{- end }}
 {{- end }}
 

--- a/sense/dashboard/templates/_envvars.tpl
+++ b/sense/dashboard/templates/_envvars.tpl
@@ -30,12 +30,9 @@
       name: {{ $e.secret }}
       key: {{ $e.key }}
           {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
             {{- end }}
-          {{- end }}
 {{- end }}
 
 {{- /* merged envvars for dashboard sidecar*/}}

--- a/sense/slo/templates/_envvars.tpl
+++ b/sense/slo/templates/_envvars.tpl
@@ -30,11 +30,8 @@
       name: {{ $e.secret }}
       key: {{ $e.key }}
           {{- else if eq $e.type "value" }}
-          {{- /* The following removes any undefined values. At this stage, it means both the local and global values are undefined, so its best to just get rid of it */}}
-            {{- if (tpl $e.value $top) ne "" }}
 - name: {{ $envName }}
   value: {{ tpl $e.value $top | quote }} 
-            {{- end }}
           {{- end }}
 {{- end }}
 


### PR DESCRIPTION
After upgrading helm to v3.3.4, I started to get the following error:

```
Error: template: fabric/charts/jwt/templates/jwt.yaml:51:12: executing "fabric/charts/jwt/templates/jwt.yaml" at <include "sidecar.envvars" .>: error calling include: template: fabric/charts/control-api/templates/_envvars.tpl:53:10: executing "sidecar.envvars" at <include "envvar" $args>: error calling include: template: fabric/charts/control-api/templates/_envvars.tpl:36:19: executing "envvar" at <(tpl $e.value $top) ne "">: can't give argument to non-function tpl $e.value $top
make[1]: *** [fabric] Error 1
make: *** [install] Error 2
```

Due to the comment above the if statement suggested of removal 7 months ago, rather than fixing the if statement, removing them all together.

Here is the version of my helm:

```bash
$ helm version
version.BuildInfo{Version:"v3.3.4", GitCommit:"a61ce5633af99708171414353ed49547cf05013d", GitTreeState:"dirty", GoVersion:"go1.15.2"}
```

How I tested the PR:
Followed `Deploy with K3d.md`
1. `make k3d` - start a kubernetes cluster locally.
2. `export KUBECONFIG=$(k3d kubeconfig write greymatter)` - configures `kubectl` to use the local k3d cluster.
3. `make credentials` - creates a git ignored file `credentials.yaml`
4. `make secrets` - inserts data from `credentials.yaml` and `secrets/values.yaml` into the cluster as secrets
5. `make install` - installs each helm chart (spire, fabric, edge, data, sense). Make sure that the error is gone.